### PR TITLE
Mention middleman-autoprefixer in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ to `Gemfile` and write CSS in usual way:
 gem "autoprefixer-rails"
 ```
 
+### Middleman
+
+Add [middleman-autoprefixer](https://github.com/porada/middleman-autoprefixer) gem to `Gemfile`:
+
+```ruby
+gem "middleman-autoprefixer"
+```
+
+and activate the extension in your project’s `config.rb`:
+
+```ruby
+activate :autoprefixer
+```
+
 ### Ruby
 
 You can integrate Autoprefixer into your Sprockets environment


### PR DESCRIPTION
Since Middleman is non-plain Ruby and uses Sprockets, I let myself add the Middleman extension in the Usage right after Ruby on Rails section.
