### PR TITLE
Actually fixing the angles in degrees

### DIFF
--- a/lib/autoprefixer/hacks/gradient.coffee
+++ b/lib/autoprefixer/hacks/gradient.coffee
@@ -37,7 +37,7 @@ class Gradient extends Value
       if params.length > 0
         if params[0][0..2] == 'to '
           params[0] = @fixDirection(params[0])
-        else if prefix == '-webkit-' and params[0].indexOf('deg') != -1
+        else if params[0].indexOf('deg') != -1
           params[0] = @fixAngle(params[0])
       before + prefix + @name + '(' + params.join(', ') + ')'
 
@@ -58,9 +58,7 @@ class Gradient extends Value
 
   # Add 90 degrees
   fixAngle: (param) ->
-    param  = parseInt(param)
-    param += 90
-    param -= 360 if param > 360
+    param = parseFloat((Math.abs(450 - parseFloat(param)) % 360).toFixed(3))
     "#{param}deg"
 
   # Remove old WebKit gradient too

--- a/test/cases/autoprefixer.gradient.css
+++ b/test/cases/autoprefixer.gradient.css
@@ -1,6 +1,7 @@
 a {
-    background: linear-gradient(350deg, white, black),
+    background: linear-gradient(350.5deg, white, black),
                 linear-gradient(-130deg, black, white),
+                linear-gradient(45deg, black, white),
                 linear-gradient(black, white);
 }
 

--- a/test/cases/autoprefixer.gradient.out.css
+++ b/test/cases/autoprefixer.gradient.out.css
@@ -1,12 +1,15 @@
 a {
-    background: -webkit-linear-gradient(80deg, white, black),
-                -webkit-linear-gradient(-40deg, black, white),
+    background: -webkit-linear-gradient(99.5deg, white, black),
+                -webkit-linear-gradient(220deg, black, white),
+                -webkit-linear-gradient(45deg, black, white),
                 -webkit-linear-gradient(black, white);
-    background: -o-linear-gradient(350deg, white, black),
-                -o-linear-gradient(-130deg, black, white),
+    background: -o-linear-gradient(99.5deg, white, black),
+                -o-linear-gradient(220deg, black, white),
+                -o-linear-gradient(45deg, black, white),
                 -o-linear-gradient(black, white);
-    background: linear-gradient(350deg, white, black),
+    background: linear-gradient(350.5deg, white, black),
                 linear-gradient(-130deg, black, white),
+                linear-gradient(45deg, black, white),
                 linear-gradient(black, white);
 }
 


### PR DESCRIPTION
Right now the `fixAngle` function is broken, and the tests are just wrong.
1. This hack should be applied to any prefixed gradient, not only for `-webkit-`.
2. The actual formula is not the one you had here (see [this article](http://blogs.msdn.com/b/ie/archive/2012/06/25/unprefixed-css3-gradients-in-ie10.aspx) for example), so I replaced it and fixed the tests.

I didn't wrote in coffee before, so you could fix any codestyle issues I have :)
