### PR TITLE
Don’t use forks for ::selection and ::placeholder data anymore

### DIFF
--- a/updaters/prefixes.coffee
+++ b/updaters/prefixes.coffee
@@ -135,15 +135,13 @@ updater.feature 'border-image.json', (browsers) ->
           browsers: browsers
 
 # Selection selector
-# Wait for https://github.com/Fyrd/caniuse/pull/269
-updater.fork 'porada/patch-1', 'css-selection.json', (browsers) ->
+updater.feature 'css-selection.json', (browsers) ->
   prefix '::selection',
           selector: true,
           browsers: browsers
 
 # Placeholder selector
-# Wait for https://github.com/Fyrd/caniuse/pull/272
-updater.fork 'ai/css-placeholder', 'css-placeholder.json', (browsers) ->
+updater.feature 'css-placeholder.json', (browsers) ->
   prefix '::placeholder',
           selector: true,
           browsers: browsers


### PR DESCRIPTION
Both pull request have been merged, so we can use the source repository.
