### PR TITLE
Fix parser bug

### DIFF
--- a/lib/autoprefixer.coffee
+++ b/lib/autoprefixer.coffee
@@ -81,7 +81,7 @@ class Autoprefixer
 
   # Remove /**/ in non-IE6 declaration, until CSS parser has this issue
   removeBadComments: (css) ->
-    css.replace(/\/\*[^\*]*\{[^\*]*\*\//g, '')
+    css.replace(/\/\*[^\*]*\}[^\*]*\*\//g, '')
 
 # Lazy load for Autoprefixer with default browsers
 autoprefixer.default = ->

--- a/test/autoprefixer.coffee
+++ b/test/autoprefixer.coffee
@@ -75,7 +75,7 @@ describe 'Autoprefixer', ->
     it 'parses difficult files', ->
       input  = cases.read('autoprefixer/syntax')
       output = cleaner.compile(input)
-      compare(input.replace('/*{}*/', ''), output)
+      compare(input.replace(/\/\*[\{\}]+\*\//g, ''), output)
 
     it 'marks parsing errors', ->
       error = null

--- a/test/cases/autoprefixer/syntax.css
+++ b/test/cases/autoprefixer/syntax.css
@@ -13,5 +13,5 @@
 a {
     /* c */
     color/**/: white;
-    padding: 0 /*{}*/ 1px;
+    padding: 0 /*{}*/ 1px /*}*/ 2px;
 }


### PR DESCRIPTION
Парсер падает потому что в комментарии находит закрывающую кавычку и считает что получил полную ноду. Потом парсит остаток значения у свойства как селектор следующей ноды и валится не сумев найти открывающую кавычку ноды. Т.е на a { padding: 0 /_{}_/ 1px; } он упадет с ошибкой. Правильная регулярка: \/*[^*]_}[^\_]_\_\/
