### PR TITLE
Readme fix: AutoprefixerRails.compile is an undefined method

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ AutoprefixerRails.install(sprockets_env)
 or process CSS from plain Ruby:
 
 ```ruby
-prefixed = AutoprefixerRails.compile(css)
+prefixed = AutoprefixerRails.process(css)
 ```
 
 ### CodeKit


### PR DESCRIPTION
For AutoprefixerRails, `compile` is the wrong method. It should be `process`.
