### PR TITLE
Do not ignore color stop positions for the first and last gradient colors

### DIFF
--- a/lib/hacks/gradient.coffee
+++ b/lib/hacks/gradient.coffee
@@ -129,9 +129,9 @@ class Gradient extends Value
         color   += ' ' + position
         position = undefined
 
-      if i == 1
+      if i == 1 and (position is undefined or position == '0%')
         "from(#{color})"
-      else if i == params.length - 1
+      else if i == params.length - 1 and (position is undefined or position == '100%')
         "to(#{color})"
       else if position
         "color-stop(#{position}, #{color})"


### PR DESCRIPTION
Browsers: `android 2.3`

Input:

``` css
.a {
    background: linear-gradient(to right, rgba(255,255,255,0) 30%,rgba(255,255,255,1) 100%);
}
```

Output (before fix):

``` css
.a {
    background: -webkit-gradient(linear, left top, right top, from(rgba(255,255,255,0)), to(rgba(255,255,255,1)));
    background: linear-gradient(to right, rgba(255,255,255,0) 30%,rgba(255,255,255,1) 100%);
}
```

Output (after fix):

``` css
.a {
    background: -webkit-gradient(linear, left top, right top, color-stop(30%, rgba(255,255,255,0)), to(rgba(255,255,255,1)));
    background: linear-gradient(to right, rgba(255,255,255,0) 30%,rgba(255,255,255,1) 100%);
}
```
