### PR TITLE
Cursor: Fix Zoom and Grab prefixing ranges

### DIFF
--- a/updaters/prefixes.coffee
+++ b/updaters/prefixes.coffee
@@ -170,11 +170,23 @@ module.exports = (updater) ->
                      'height', 'min-height', 'max-height']
             browsers: browsers
 
-  # Zoom and grub cursos
+  # Zoom and grab cursor
   @feature 'css3-cursors-newer', (browsers) =>
-    prefix 'zoom-in', 'zoom-out', 'grab', 'grabbing',
+    prefix 'zoom-in', 'zoom-out',
             props:  ['cursor']
-            browsers: browsers
+            # Chrome added this 3.0, but is flagged as starting in 4 because
+            # that was when the grab/grabbing prefixed property was added
+            browsers: browsers.push ["chrome 3"]
+    prefix 'grab', 'grabbing',
+            props:  ['cursor']
+            # Firefox didn't unprefix the grab/grabbing cursors till v27, but the
+            # caniuse data flagged it as clean in 24 because the zoom-in/zoom-out
+            # version was dropped.
+            browsers: browsers.push [
+              "ff 24"
+              "ff 25"
+              "ff 26"
+            ]
 
   # Sticky position
   @feature 'css-sticky', (browsers) =>


### PR DESCRIPTION
- Firefox only unprefixed the zoom properties in 24, not the grab properties
- Chrome supported the zoom properties in 3 as well, but the grab is correct that it didn't support them till 4
- Typos in comments

Note: I couldn't regenerate the file right now because of a proxy issue so it may be best to hold off merging unless you test yourself.
