### PR TITLE
Add link to brunch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ gulp.src('./css/*.css')
   .pipe(gulp.dest('./dist/'));
 ```
 
+### Brunch
+
+You can use the
+[autoprefixer-brunch](https://github.com/lydell/autoprefixer-brunch)
+plugin for [Brunch](http://brunch.io/).
+
 ### Compass
 
 If you use Compass binary to compile your styles, you can easily integrate


### PR DESCRIPTION
Are the different plugins ordered in some way? I put it after grunt and gulp since those feels like having the most in common with brunch, but I’m not sure.
