### PR TITLE
Fix origin declaration style on cloning node

### DIFF
--- a/lib/declaration.coffee
+++ b/lib/declaration.coffee
@@ -76,6 +76,12 @@ class Declaration extends Prefixer
       cloned.before = @calcBefore(prefixes, decl, prefix)
     decl.parent.insertBefore(decl, cloned)
 
+  # Save origin declaration style
+  clone: (decl, overrides) ->
+    cloned = super
+    cloned.between = decl.between
+    cloned
+
   # Clone and add prefixes for declaration
   add: (decl, prefix, prefixes) ->
     prefixed  = @prefixed(decl.prop, prefix)

--- a/lib/prefixer.coffee
+++ b/lib/prefixer.coffee
@@ -20,7 +20,6 @@ class Prefixer
   # Clone node and clean autprefixer custom caches
   @clone: (node, overrides) ->
     cloned = node.clone(overrides)
-    cloned.between = node.between
     delete cloned._autoprefixerPrefix
     delete cloned._autoprefixerValues
     cloned

--- a/lib/value.coffee
+++ b/lib/value.coffee
@@ -26,6 +26,7 @@ class Value extends Prefixer
 
           unless already
             cloned = @clone(decl, value: value)
+            cloned.between = decl.between
             decl.parent.insertBefore(decl, cloned)
 
   # Is declaration need to be prefixed


### PR DESCRIPTION
Related to https://github.com/ai/postcss/issues/56, declaration style has to be kept even when values are prefixed. So directly in Prefixer?
