### PR TITLE
Don't add webkit prefixes when a data-uri is set

### DIFF
--- a/lib/hacks/filter.coffee
+++ b/lib/hacks/filter.coffee
@@ -7,6 +7,7 @@ class Filter extends Declaration
   check: (decl) ->
     v = decl.value
     v.toLowerCase().indexOf('alpha(') == -1 and
-      v.indexOf('DXImageTransform.Microsoft') == -1
+      v.indexOf('DXImageTransform.Microsoft') == -1 and
+      v.indexOf('data:image/svg+xml') == -1
 
 module.exports = Filter


### PR DESCRIPTION
I've made a "CSS shorthand filters to SVG" processor here: https://github.com/iamvdo/pleeease-filters and integrated in Pleeease.
WebKit browsers don't support SVG filters through data URI, so prefixes can be removed safely in this case.
