### PR TITLE
Fix incorrect example in gulp section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ gulp.task('autoprefixer', function () {
 
     return gulp.src('./src/*.css')
         .pipe(sourcemaps.init())
-        .pipe(postcss( autoprefixer ))
+        .pipe(postcss([autoprefixer]))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('./dest'));
 });


### PR DESCRIPTION
Hello!

I've fixed little error in the Gulp section in README file that causes next error message:  "Please provide array of postcss processors!"
