### PR TITLE
Ensure all output is written before exiting (stops truncation)

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -74,10 +74,10 @@ Browsers:
   or last version: '-b "last 2 versions"'.`);
     }
 
-    // Print to stdout
-    print(str) {
+    // Print to stdout, with optional callback
+    print(str, done) {
         str = str.replace(/\n$/, '');
-        this.stdout.write(str + "\n");
+        this.stdout.write(str + "\n", done);
     }
 
     // Print to stdout
@@ -263,8 +263,9 @@ Browsers:
         if ( !result ) return this.endWork();
 
         if ( output == '-' ) {
-            this.print(result.css);
-            this.endWork();
+            this.print(result.css, () => {
+                this.endWork();
+            });
         } else {
             fs.outputFile(output, result.css, (error) => {
                 if (error) this.error('autoprefixer: ' + error);

--- a/test/binary.js
+++ b/test/binary.js
@@ -11,8 +11,11 @@ class StringBuffer {
         this.content = '';
     }
 
-    write(str) {
+    write(str, callback) {
         this.content += str;
+        if ( callback ) {
+            callback();
+        }
     }
 
     resume() {


### PR DESCRIPTION
This surfaces in cases where `process.exit()` is called (from `endWork`) before all writes have flushed.

Reproducible on io.js when piping a large output to another process, eg, tail – the output ends up truncated.

Before this PR:
```console
$ cat my.css | autoprefixer -b '> 1%' | tail -3
.tap-to-enlarge {
  font-size: 1rem;
  display: bloc
```
(ie, truncation)

After this PR:
```console
$ cat my.css | autoprefixer -b '> 1%' | tail -3
  .menu-item-back > .menu-link {
    color: #fff; }

```
(no truncation)

There are a number of other places where providing a callback to `print` or even `error` should be done, but I only fixed the one where the problem is likely to occur – and that's when outputting to stdout – all other areas in the code *could* have problems, but are unlikely to (because they'll always likely output less than a buffer's worth of data at a time).