### PR TITLE
Only hard process.exit when there's an error

### DIFF
--- a/autoprefixer
+++ b/autoprefixer
@@ -5,6 +5,8 @@ var Binary = require('./binary');
 
 var binary = new Binary(process);
 binary.run(function () {
-    process.exit(binary.status);
+    if ( binary.status ) {
+        process.exit(binary.status);
+    }
 });
 


### PR DESCRIPTION
This allows the process to exit gracefully and ensures all writes have finished flushing.

This addresses #437 and is probably a better solution.