### PR TITLE
Fix cross-fade() not support `<number>`

### DIFF
--- a/lib/hacks/cross-fade.coffee
+++ b/lib/hacks/cross-fade.coffee
@@ -16,7 +16,7 @@ class CrossFade extends Value
         args  = value[@name.length + 1..close - 1]
 
         if prefix == '-webkit-'
-          match = args.match(/\d+%/)
+          match = args.match(/\d*.?\d+%?/)
           if match
             args  = args[match[0].length..-1].trim()
             args += ', ' + match[0]

--- a/test/cases/cross-fade.css
+++ b/test/cases/cross-fade.css
@@ -5,3 +5,19 @@ a {
 b {
     background-image: cross-fade(url(foo.png), url(bar.png));
 }
+
+h1 {
+    background-image: cross-fade(10.823% url(foo.png), url(bar.png));
+}
+
+h2 {
+    background-image: cross-fade(0.59 url(foo.png), url(bar.png));
+}
+
+h3 {
+    background-image: cross-fade(.59 url(foo.png), url(bar.png));
+}
+
+.foo {
+    background-image: cross-fade(.59 linear-gradient(white, black), radial-gradient(circle closest-corner, white, black));
+}

--- a/test/cases/cross-fade.out.css
+++ b/test/cases/cross-fade.out.css
@@ -7,3 +7,23 @@ b {
     background-image: -webkit-cross-fade(url(foo.png), url(bar.png), 0.5);
     background-image: cross-fade(url(foo.png), url(bar.png));
 }
+
+h1 {
+    background-image: -webkit-cross-fade(url(foo.png), url(bar.png), 10.823%);
+    background-image: cross-fade(10.823% url(foo.png), url(bar.png));
+}
+
+h2 {
+    background-image: -webkit-cross-fade(url(foo.png), url(bar.png), 0.59);
+    background-image: cross-fade(0.59 url(foo.png), url(bar.png));
+}
+
+h3 {
+    background-image: -webkit-cross-fade(url(foo.png), url(bar.png), .59);
+    background-image: cross-fade(.59 url(foo.png), url(bar.png));
+}
+
+.foo {
+    background-image: -webkit-cross-fade(linear-gradient(white, black), radial-gradient(circle closest-corner, white, black), .59);
+    background-image: cross-fade(.59 linear-gradient(white, black), radial-gradient(circle closest-corner, white, black));
+}


### PR DESCRIPTION
The old spec(-webkit-) support `<number>`(0.5, .5)