### PR TITLE
Wrapping ( or )

### DIFF
--- a/lib/supports.coffee
+++ b/lib/supports.coffee
@@ -62,6 +62,6 @@ class Supports
       if stringed.length == 1
         stringed[0]
       else
-        '(' + stringed.join(' or ') + ')'
+        '((' + stringed.join(') or (') + '))'
 
 module.exports = Supports


### PR DESCRIPTION
**Adding parenthesis to join so OR statements don’t conflict with nested conditions.** 
Fixes #568 

Meeting requirements from issue:
```
@supports ((perspective: 1px) and (not (-webkit-overflow-scrolling: touch))){}
```
```
@supports (((-webkit-perspective: 1px) and (not (-webkit-overflow-scrolling: touch))) or ((perspective: 1px) and (not (-webkit-overflow-scrolling: touch)))){}
```

Basic example:
```
@supports (perspective: 1px){}
```
```
@supports (((-webkit-perspective: 1px)) or ((perspective: 1px))){}
```

not ( example ):
```
@supports not (display: flex){}
```
```
@supports not (((display: -webkit-box)) or ((display: -webkit-flex)) or ((display: -ms-flexbox)) or ((display: flex))){}
```

In cases where parenthesis are redundant 
http://www.w3.org/TR/css3-conditional/#at-supports  [Example 10]
> The syntax allows extra parentheses when they are not needed. 