### PR TITLE
Fix text-emphasis-position reverse value order

### DIFF
--- a/lib/hacks/text-emphasis-position.coffee
+++ b/lib/hacks/text-emphasis-position.coffee
@@ -5,7 +5,7 @@ class TextEmphasisPosition extends Declaration
 
   set: (decl, prefix) ->
     if prefix == '-webkit-'
-      decl.value = decl.value.replace(/\s+(right|left)(\s*)/i, '$2')
+      decl.value = decl.value.replace(/\s*(right|left)\s*/i, '')
       super(decl, prefix)
     else
       super

--- a/test/cases/text-emphasis-position.css
+++ b/test/cases/text-emphasis-position.css
@@ -1,3 +1,12 @@
 a {
     text-emphasis-position: over left;
 }
+
+em {
+    text-emphasis-position: under left;
+}
+
+/* Reverse order */
+em {
+    text-emphasis-position: left over;
+}

--- a/test/cases/text-emphasis-position.out.css
+++ b/test/cases/text-emphasis-position.out.css
@@ -2,3 +2,14 @@ a {
     -webkit-text-emphasis-position: over;
             text-emphasis-position: over left;
 }
+
+em {
+    -webkit-text-emphasis-position: under;
+            text-emphasis-position: under left;
+}
+
+/* Reverse order */
+em {
+    -webkit-text-emphasis-position: over;
+            text-emphasis-position: left over;
+}


### PR DESCRIPTION
Reverse value order 

input: 

```css
em {
    text-emphasis-position: left over;
}
```

output:

```css
em {
    -webkit-text-emphasis-position: over;
            text-emphasis-position: left over;
}
```