### PR TITLE
indexOf undefined

### DIFF
--- a/lib/transition.coffee
+++ b/lib/transition.coffee
@@ -59,10 +59,10 @@ class Transition
   checkForWarning: (result, decl) ->
     if decl.prop == 'transition-property'
       decl.parent.each (i) ->
-        return if i.prop.indexOf('transition-') != 0
+        return if i.prop?.indexOf('transition-') != 0
         return if i.prop == 'transition-property'
 
-        if i.value.indexOf(',') != -1
+        if not i.value or i.value.indexOf(',') != -1
           decl.warn(result, 'Replace transition-property to transition, ' +
                             'because Autoprefixer could not support ' +
                             'any cases of transition-property ' +


### PR DESCRIPTION
Found this error in angular-material library:

```
Cannot read property 'indexOf' of undefined
```

It happens for this code:

```
  opacity: 1;
  -webkit-transform: translate3d(0, 0, 0) rotateZ(0deg);
          transform: translate3d(0, 0, 0) rotateZ(0deg);
  transition: 0.2s linear;
  transition-property: -webkit-transform, opacity;
  transition-property: transform, opacity;
```