### PR TITLE
Add .json file-ending to all relevant require statements

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -45,20 +45,20 @@ add = (names..., data) ->
 module.exports = result
 
 # Border Radius
-feature require('caniuse-db/features-json/border-radius'), (browsers) ->
+feature require('caniuse-db/features-json/border-radius.json'), (browsers) ->
   prefix 'border-radius', 'border-top-left-radius', 'border-top-right-radius',
          'border-bottom-right-radius', 'border-bottom-left-radius',
           mistakes: ['-khtml-', '-ms-', '-o-']
           browsers: browsers
 
 # Box Shadow
-feature require('caniuse-db/features-json/css-boxshadow'), (browsers) ->
+feature require('caniuse-db/features-json/css-boxshadow.json'), (browsers) ->
   prefix 'box-shadow',
           mistakes: ['-khtml-']
           browsers: browsers
 
 # Animation
-feature require('caniuse-db/features-json/css-animation'), (browsers) ->
+feature require('caniuse-db/features-json/css-animation.json'), (browsers) ->
   prefix 'animation', 'animation-name', 'animation-duration',
          'animation-delay', 'animation-direction', 'animation-fill-mode',
          'animation-iteration-count', 'animation-play-state',
@@ -67,19 +67,19 @@ feature require('caniuse-db/features-json/css-animation'), (browsers) ->
           browsers: browsers
 
 # Transition
-feature require('caniuse-db/features-json/css-transitions'), (browsers) ->
+feature require('caniuse-db/features-json/css-transitions.json'), (browsers) ->
   prefix 'transition', 'transition-property', 'transition-duration',
          'transition-delay', 'transition-timing-function',
           mistakes: ['-khtml-', '-ms-']
           browsers: browsers
 
 # Transform 2D
-feature require('caniuse-db/features-json/transforms2d'), (browsers) ->
+feature require('caniuse-db/features-json/transforms2d.json'), (browsers) ->
   prefix 'transform', 'transform-origin',
           browsers: browsers
 
 # Transform 3D
-feature require('caniuse-db/features-json/transforms3d'), (browsers) ->
+feature require('caniuse-db/features-json/transforms3d.json'), (browsers) ->
   prefix 'perspective', 'perspective-origin',
           browsers: browsers
 
@@ -88,7 +88,7 @@ feature require('caniuse-db/features-json/transforms3d'), (browsers) ->
           browsers: browsers
 
 # Gradients
-gradients = require('caniuse-db/features-json/css-gradients')
+gradients = require('caniuse-db/features-json/css-gradients.json')
 
 feature gradients, match: /y\sx/, (browsers) ->
   prefix 'linear-gradient', 'repeating-linear-gradient',
@@ -105,36 +105,42 @@ feature gradients, match: /a\sx/, (browsers) ->
        browsers: browsers
 
 # Box sizing
-feature require('caniuse-db/features-json/css3-boxsizing'), (browsers) ->
+feature require('caniuse-db/features-json/css3-boxsizing.json'), (browsers) ->
   prefix 'box-sizing',
           browsers: browsers
 
 # Filter Effects
-feature require('caniuse-db/features-json/css-filters'), (browsers) ->
+feature require('caniuse-db/features-json/css-filters.json'), (browsers) ->
   prefix 'filter',
           browsers: browsers
 
 # filter() function
-feature require('caniuse-db/features-json/css-filter-function'), (browsers) ->
+filterFunction = require('caniuse-db/features-json/css-filter-function.json')
+
+feature filterFunction, (browsers) ->
   prefix 'filter-function',
           props: ['background', 'background-image', 'border-image', 'mask',
                   'list-style', 'list-style-image', 'content', 'mask-image']
           browsers: browsers
 
 # Backdrop-filter
-feature require('caniuse-db/features-json/css-backdrop-filter'), (browsers) ->
+backdropFilter = require('caniuse-db/features-json/css-backdrop-filter.json')
+
+feature backdropFilter, (browsers) ->
   prefix 'backdrop-filter',
           browsers: browsers
 
 # element() function
-feature require('caniuse-db/features-json/css-element-function'), (browsers) ->
+elementFunction = require('caniuse-db/features-json/css-element-function.json')
+
+feature elementFunction, (browsers) ->
   prefix 'element',
           props: ['background', 'background-image', 'border-image', 'mask',
                   'list-style', 'list-style-image', 'content', 'mask-image']
           browsers: browsers
 
 # Multicolumns
-feature require('caniuse-db/features-json/multicolumn'), (browsers) ->
+feature require('caniuse-db/features-json/multicolumn.json'), (browsers) ->
   prefix 'columns', 'column-width', 'column-gap',
          'column-rule', 'column-rule-color', 'column-rule-width',
           browsers: browsers
@@ -144,13 +150,15 @@ feature require('caniuse-db/features-json/multicolumn'), (browsers) ->
           browsers: browsers
 
 # User select
-feature require('caniuse-db/features-json/user-select-none'), (browsers) ->
+userSelectNone = require('caniuse-db/features-json/user-select-none.json')
+
+feature userSelectNone, (browsers) ->
   prefix 'user-select',
           mistakes: ['-khtml-']
           browsers: browsers
 
 # Flexible Box Layout
-flexbox = require('caniuse-db/features-json/flexbox')
+flexbox = require('caniuse-db/features-json/flexbox.json')
 
 feature flexbox, match: /a\sx/, (browsers) ->
   browsers = browsers.map (i) -> if /ie|firefox/.test(i) then i else "#{i} 2009"
@@ -173,35 +181,37 @@ feature flexbox, match: /y\sx/, (browsers) ->
        browsers: browsers
 
 # calc() unit
-feature require('caniuse-db/features-json/calc'), (browsers) ->
+feature require('caniuse-db/features-json/calc.json'), (browsers) ->
   prefix 'calc',
           props:  ['*']
           browsers: browsers
 
 # Background options
-feature require('caniuse-db/features-json/background-img-opts'), (browsers) ->
+bckgrndImgOpts = require('caniuse-db/features-json/background-img-opts.json')
+
+feature bckgrndImgOpts, (browsers) ->
   prefix 'background-clip', 'background-origin', 'background-size',
           browsers: browsers
 
 # Font feature settings
-feature require('caniuse-db/features-json/font-feature'), (browsers) ->
+feature require('caniuse-db/features-json/font-feature.json'), (browsers) ->
   prefix 'font-feature-settings', 'font-variant-ligatures',
          'font-language-override','font-kerning',
           browsers: browsers
 
 # Border image
-feature require('caniuse-db/features-json/border-image'), (browsers) ->
+feature require('caniuse-db/features-json/border-image.json'), (browsers) ->
   prefix 'border-image',
           browsers: browsers
 
 # Selection selector
-feature require('caniuse-db/features-json/css-selection'), (browsers) ->
+feature require('caniuse-db/features-json/css-selection.json'), (browsers) ->
   prefix '::selection',
           selector: true,
           browsers: browsers
 
 # Placeholder selector
-feature require('caniuse-db/features-json/css-placeholder'), (browsers) ->
+feature require('caniuse-db/features-json/css-placeholder.json'), (browsers) ->
   browsers = browsers.map (i) ->
     [name, version] = i.split(' ')
     if name == 'firefox' and parseFloat(version) <= 18 then i + ' old' else i
@@ -211,12 +221,12 @@ feature require('caniuse-db/features-json/css-placeholder'), (browsers) ->
           browsers: browsers
 
 # Hyphenation
-feature require('caniuse-db/features-json/css-hyphens'), (browsers) ->
+feature require('caniuse-db/features-json/css-hyphens.json'), (browsers) ->
   prefix 'hyphens',
           browsers: browsers
 
 # Fullscreen selector
-fullscreen = require('caniuse-db/features-json/fullscreen')
+fullscreen = require('caniuse-db/features-json/fullscreen.json')
 
 feature fullscreen, (browsers) ->
   prefix ':fullscreen',
@@ -229,12 +239,12 @@ feature fullscreen, match: /x(\s#2|$)/, (browsers) ->
           browsers: browsers
 
 # Tab size
-feature require('caniuse-db/features-json/css3-tabsize'), (browsers) ->
+feature require('caniuse-db/features-json/css3-tabsize.json'), (browsers) ->
   prefix 'tab-size',
           browsers: browsers
 
 # Intrinsic & extrinsic sizing
-feature require('caniuse-db/features-json/intrinsic-width'), (browsers) ->
+feature require('caniuse-db/features-json/intrinsic-width.json'), (browsers) ->
   prefix 'max-content', 'min-content', 'fit-content', 'fill', 'fill-available',
           props:  ['width',  'min-width',  'max-width',
                    'height', 'min-height', 'max-height',
@@ -243,42 +253,47 @@ feature require('caniuse-db/features-json/intrinsic-width'), (browsers) ->
           browsers: browsers
 
 # Zoom cursors
-feature require('caniuse-db/features-json/css3-cursors-newer'), (browsers) ->
+cursorsNewer = require('caniuse-db/features-json/css3-cursors-newer.json')
+
+feature cursorsNewer, (browsers) ->
   prefix 'zoom-in', 'zoom-out',
           props:  ['cursor']
           browsers: browsers
 
 # Grab cursors
-feature require('caniuse-db/features-json/css3-cursors-grab'), (browsers) ->
+cursorsGrab = require('caniuse-db/features-json/css3-cursors-grab.json')
+feature cursorsGrab, (browsers) ->
   prefix 'grab', 'grabbing',
           props:  ['cursor']
           browsers: browsers
 
 # Sticky position
-feature require('caniuse-db/features-json/css-sticky'), (browsers) ->
+feature require('caniuse-db/features-json/css-sticky.json'), (browsers) ->
   prefix 'sticky',
           props:  ['position']
           browsers: browsers
 
 # Pointer Events
-feature require('caniuse-db/features-json/pointer'), (browsers) ->
+feature require('caniuse-db/features-json/pointer.json'), (browsers) ->
   prefix 'touch-action',
           browsers: browsers
 
 # Text decoration
-feature require('caniuse-db/features-json/text-decoration'), (browsers) ->
+feature require('caniuse-db/features-json/text-decoration.json'), (browsers) ->
   prefix 'text-decoration-style',
          'text-decoration-line',
          'text-decoration-color',
           browsers: browsers
 
 # Text Size Adjust
-feature require('caniuse-db/features-json/text-size-adjust'), (browsers) ->
+textSizeAdjust = require('caniuse-db/features-json/text-size-adjust.json')
+
+feature textSizeAdjust, (browsers) ->
   prefix 'text-size-adjust',
           browsers: browsers
 
 # CSS Masks
-feature require('caniuse-db/features-json/css-masks'), (browsers) ->
+feature require('caniuse-db/features-json/css-masks.json'), (browsers) ->
   prefix 'mask-clip', 'mask-composite', 'mask-image',
          'mask-origin', 'mask-repeat', 'mask-border-repeat',
          'mask-border-source',
@@ -289,52 +304,57 @@ feature require('caniuse-db/features-json/css-masks'), (browsers) ->
           browsers: browsers
 
 # Fragmented Borders and Backgrounds
-feature require('caniuse-db/features-json/css-boxdecorationbreak'), (brwsrs) ->
+boxdecorbreak = require('caniuse-db/features-json/css-boxdecorationbreak.json')
+
+feature boxdecorbreak, (browsers) ->
   prefix 'box-decoration-break',
-          browsers: brwsrs
+          browsers: browsers
 
 # CSS3 object-fit/object-position
-feature require('caniuse-db/features-json/object-fit'), (browsers) ->
+feature require('caniuse-db/features-json/object-fit.json'), (browsers) ->
   prefix 'object-fit',
          'object-position',
           browsers: browsers
 
 # CSS Shapes
-feature require('caniuse-db/features-json/css-shapes'), (browsers) ->
+feature require('caniuse-db/features-json/css-shapes.json'), (browsers) ->
   prefix 'shape-margin',
          'shape-outside',
          'shape-image-threshold',
           browsers: browsers
 
 # CSS3 text-overflow
-feature require('caniuse-db/features-json/text-overflow'), (browsers) ->
+feature require('caniuse-db/features-json/text-overflow.json'), (browsers) ->
   prefix 'text-overflow',
           browsers: browsers
 
 # CSS3 text-emphasis
-feature require('caniuse-db/features-json/text-emphasis'), (browsers) ->
+feature require('caniuse-db/features-json/text-emphasis.json'), (browsers) ->
   prefix 'text-emphasis',
           browsers: browsers
 
 # Viewport at-rule
-feature require('caniuse-db/features-json/css-deviceadaptation'), (browsers) ->
+devdaptation = require('caniuse-db/features-json/css-deviceadaptation.json')
+feature devdaptation, (browsers) ->
   prefix '@viewport',
           browsers: browsers
 
 # Resolution Media Queries
-resolution = require('caniuse-db/features-json/css-media-resolution')
+resolution = require('caniuse-db/features-json/css-media-resolution.json')
 
 feature resolution, match: /( x($| )|a #3)/, (browsers) ->
   prefix '@resolution',
           browsers: browsers
 
 # CSS text-align-last
-feature require('caniuse-db/features-json/css-text-align-last'), (browsers) ->
+textAlignLast = require('caniuse-db/features-json/css-text-align-last.json')
+
+feature textAlignLast, (browsers) ->
   prefix 'text-align-last',
           browsers: browsers
 
 # Crisp Edges Image Rendering Algorithm
-crispedges = require('caniuse-db/features-json/css-crisp-edges')
+crispedges = require('caniuse-db/features-json/css-crisp-edges.json')
 
 feature crispedges, match: /y x/, (browsers) ->
   prefix 'pixelated',
@@ -346,7 +366,7 @@ feature crispedges, match: /a x #2/, (browsers) ->
           browsers: browsers
 
 # Logical Properties
-logicalProps = require('caniuse-db/features-json/css-logical-props')
+logicalProps = require('caniuse-db/features-json/css-logical-props.json')
 
 feature logicalProps, (browsers) ->
   prefix 'border-inline-start',  'border-inline-end',
@@ -361,12 +381,12 @@ feature logicalProps, match: /x\s#2/, (browsers) ->
           browsers: browsers
 
 # CSS appearance
-feature require('caniuse-db/features-json/css-appearance'), (browsers) ->
+feature require('caniuse-db/features-json/css-appearance.json'), (browsers) ->
   prefix 'appearance',
           browsers: browsers
 
 # CSS Scroll snap points
-feature require('caniuse-db/features-json/css-snappoints'), (browsers) ->
+feature require('caniuse-db/features-json/css-snappoints.json'), (browsers) ->
   prefix 'scroll-snap-type',
          'scroll-snap-coordinate',
          'scroll-snap-destination',
@@ -374,20 +394,20 @@ feature require('caniuse-db/features-json/css-snappoints'), (browsers) ->
           browsers: browsers
 
 # CSS Regions
-feature require('caniuse-db/features-json/css-regions'), (browsers) ->
+feature require('caniuse-db/features-json/css-regions.json'), (browsers) ->
   prefix 'flow-into', 'flow-from',
          'region-fragment',
           browsers: browsers
 
 # CSS image-set
-feature require('caniuse-db/features-json/css-image-set'), (browsers) ->
+feature require('caniuse-db/features-json/css-image-set.json'), (browsers) ->
   prefix 'image-set',
           props: ['background', 'background-image', 'border-image', 'mask',
                   'list-style', 'list-style-image', 'content', 'mask-image']
           browsers: browsers
 
 # Writing Mode
-writingMode = require('caniuse-db/features-json/css-writing-mode')
+writingMode = require('caniuse-db/features-json/css-writing-mode.json')
 feature writingMode, match: /a|x/, (browsers) ->
   prefix 'writing-mode',
           browsers: browsers
@@ -424,6 +444,8 @@ feature require('caniuse-db/features-json/css-grid.json'), (browsers) ->
           browsers: browsers
 
 # CSS text-spacing
-feature require('caniuse-db/features-json/css-text-spacing.json'), (browsers) ->
+textSpacing = require('caniuse-db/features-json/css-text-spacing.json')
+
+feature textSpacing, (browsers) ->
   prefix 'text-spacing',
           browsers: browsers

--- a/lib/autoprefixer.coffee
+++ b/lib/autoprefixer.coffee
@@ -56,7 +56,7 @@ module.exports = postcss.plugin 'autoprefixer', (reqs...) ->
 
 # Autoprefixer data
 module.exports.data =
-  browsers: require('caniuse-db/data').agents
+  browsers: require('caniuse-db/data.json').agents
   prefixes: require('../data/prefixes')
 
 # Autoprefixer default browsers

--- a/lib/browsers.coffee
+++ b/lib/browsers.coffee
@@ -8,7 +8,7 @@ class Browsers
   @prefixes: ->
     return @prefixesCache if @prefixesCache
 
-    data = require('caniuse-db/data').agents
+    data = require('caniuse-db/data.json').agents
     @prefixesCache = utils.uniq("-#{i.prefix}-" for name, i of data).
                            sort (a, b) -> b.length - a.length
 

--- a/lib/supports.coffee
+++ b/lib/supports.coffee
@@ -6,7 +6,7 @@ utils    = require('./utils')
 postcss = require('postcss')
 
 supported = []
-data      = require('caniuse-db/features-json/css-featurequeries')
+data      = require('caniuse-db/features-json/css-featurequeries.json')
 for browser, versions of data.stats
   for version, support of versions
     supported.push(browser + ' ' + version) if /y/.test(support)

--- a/test/browsers.coffee
+++ b/test/browsers.coffee
@@ -1,6 +1,6 @@
 Browsers = require('../lib/browsers')
 
-data = require('caniuse-db/data').agents
+data = require('caniuse-db/data.json').agents
 
 describe 'Browsers', ->
 

--- a/test/info.coffee
+++ b/test/info.coffee
@@ -3,7 +3,7 @@ Prefixes = require('../lib/prefixes')
 info     = require('../lib/info')
 
 data =
-  browsers: require('caniuse-db/data').agents
+  browsers: require('caniuse-db/data.json').agents
   prefixes:
     a:
       browsers: ['firefox 21', 'firefox 20', 'chrome 30']

--- a/test/prefixes.coffee
+++ b/test/prefixes.coffee
@@ -8,7 +8,7 @@ Value       = require('../lib/value')
 parse       = require('postcss/lib/parse')
 
 data =
-  browsers: require('caniuse-db/data').agents
+  browsers: require('caniuse-db/data.json').agents
   prefixes:
     a:
       browsers: ['firefox 21', 'firefox 20 old', 'chrome 30', 'ie 6']


### PR DESCRIPTION
It's bad practice to implicitly load files by name without specifying
their extension. This fix helps autoprefixer work more easily with
jspm's expectations of how files should be require'd.

This resolves #618 and also respects 80-char max line length.