### PR TITLE
Don't warn on display:box without flexbox option

### DIFF
--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -35,7 +35,8 @@ class Processor
     css.walkDecls (decl) =>
       return if @disabled(decl)
 
-      if decl.prop == 'display' and decl.value == 'box'
+      if @prefixes.options.flexbox != false and decl.prop == 'display' and
+          decl.value == 'box'
         result.warn('You should write display: flex by final spec ' +
                     'instead of display: box', node: decl)
         return


### PR DESCRIPTION
Don't know if you'd agree with this but we're currently using Bourbon mixins in our codebase and removing this warning seems to make sense to me.

Was also wondering why this is looking for the `flexbox` option and not `grid`? https://github.com/stevoland/autoprefixer/blob/fdd71f763828fdfab6b07859a549419f4e02ab2a/lib/processor.coffee#L58