### PR TITLE
Fix link to autoprefixer-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,11 @@ with [other PostCSS plugins].
 
 * **Less**: [less-plugin-autoprefix]
 * **Stylus**: [autoprefixer-stylus]
-* **Compass**: [autoprefixer-rails]
+* **Compass**: [autoprefixer-rails#compass]
 
- [less-plugin-autoprefix]: https://github.com/less/less-plugin-autoprefix
- [autoprefixer-stylus]:    https://github.com/jenius/autoprefixer-stylus
- [autoprefixer-rails]:     https://github.com/ai/autoprefixer-rails#compass
+[less-plugin-autoprefix]: https://github.com/less/less-plugin-autoprefix
+[autoprefixer-stylus]:    https://github.com/jenius/autoprefixer-stylus
+[autoprefixer-rails#compass]:     https://github.com/ai/autoprefixer-rails#compass
 
 ### CSS-in-JS
 


### PR DESCRIPTION
Links can't have same name and different URLs if you use reference text in Markdown. So because of this link to Ruby on Rails version had hash `#compass` in URL. Now it fixed.