### PR TITLE
Hack for unitless 0 basis in IE10/IE11 shorthand flex

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Erik Sundahl <esundahl@gmail.com>
 Eugene Datsky <eugene@datsky.ru>
 Evilebot Tnawi <sheo13666q@gmail.com>
 Forrest York <https://github.com/badisa>
+Google Inc.
 Gregory Eremin <magnolia_fan@me.com>
 GU Yiling <justice360@gmail.com>
 Hallvord R. M. Steen <hallvord@hallvord.com>

--- a/lib/hacks/flex.coffee
+++ b/lib/hacks/flex.coffee
@@ -23,11 +23,17 @@ class Flex extends Declaration
     'flex'
 
   # Spec 2009 supports only first argument
+  # Spec 2012 disallows unitless basis
   set: (decl, prefix) ->
     spec = flexSpec(prefix)[0]
     if spec == 2009
       decl.value = list.space(decl.value)[0]
       decl.value = Flex.oldValues[decl.value] || decl.value
+      super(decl, prefix)
+    else if spec == 2012
+      components = list.space(decl.value)
+      if components.length == 3 and components[2] == '0'
+        decl.value = components[..1].concat('0px').join(' ')
       super(decl, prefix)
     else
       super

--- a/test/cases/flexbox.out.css
+++ b/test/cases/flexbox.out.css
@@ -212,6 +212,6 @@ a {
     -webkit-box-flex: -webkit-calc(1em + 1px);
     -webkit-flex: -webkit-calc(1em + 1px) 0 0;
        -moz-box-flex: calc(1em + 1px);
-        -ms-flex: calc(1em + 1px) 0 0;
+        -ms-flex: calc(1em + 1px) 0 0px;
             flex: calc(1em + 1px) 0 0;
 }


### PR DESCRIPTION
**Demo:** http://codepen.io/anon/pen/rWwaOZ
**Expected result (Chrome 55):** [Screenshot](https://cloud.githubusercontent.com/assets/79461/20585007/db4f10e8-b24b-11e6-9f89-ba120c2d28b4.png)
**Expected result (IE 11):** [Screenshot](https://cloud.githubusercontent.com/assets/79461/20585029/00e2101c-b24c-11e6-924e-15edc7ff5b6f.png)

**Overview:**

This is a workaround for [this IE10/11 bug](https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored).

Only applies when there are three components in the flex property.

This is because when there's one or two components only, it's ambiguous whether whether the first component being a unitless 0 is intended to be flex-grow or flex-basis. Browsers resolve this by treating such cases as a flex-grow of 0.

Note with IE11 that even though it understands the unprefixed flex property, we don't apply the hack there. Instead we let it treat the unprefixed version as invalid, and fall back onto -ms-flex.

Finally, although some CSS minifiers may revert the 0px to 0, we don't use 0% instead, even though many of these won't touch 0%. See [this Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=495306) for why this is the case.

**References:**

- https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flexibility
- https://www.w3.org/TR/css-flexbox-1/#flex-property
- https://www.w3.org/TR/2016/CR-css-values-3-20160929/#component-combinators

Also adds Google Inc. to the list of copyright authors.