### PR TITLE
Add yargs for mocha grep

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var path = require('path');
 var fs   = require('fs-extra');
+var yargs = require('yargs');
 
 gulp.task('clean', function (done) {
     fs.remove(path.join(__dirname, 'autoprefixer.js'), function () {
@@ -85,7 +86,8 @@ gulp.task('test', function () {
     require('should');
 
     var mocha = require('gulp-mocha');
-    return gulp.src('test/*.coffee', { read: false }).pipe(mocha());
+    return gulp.src('test/*.coffee', { read: false })
+      .pipe(mocha({ grep: yargs.argv.grep }));
 });
 
 gulp.task('default', ['lint', 'test']);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "gulp-replace": "^0.5.4",
     "mocha": "^3.2.0",
     "should": "^11.2.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^6.6.0"
   },
   "scripts": {
     "test": "gulp"


### PR DESCRIPTION
Adds the [yargs](https://www.npmjs.com/package/yargs) dev dependency to allow for test filtering.

#### Example:
`gulp test --grep 'transform'`