### PR TITLE
Fixed a typo in the code of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ a {
 }
 
 b {
-    /* autoprefixer: off */
+    /*! autoprefixer: off */
     transition: 1s; /* it will not be prefixed */
 }
 ```


### PR DESCRIPTION
Exclamation mark was missing with autoprefixer: off. Without it, it doesn't work.