### PR TITLE
Added documentation for disabling Autoprefixer in Sass/SCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,21 @@ You can also use comments recursively:
 }
 ```
 
+### Disabling in Sass/SCSS
+In Sass/SCSS you can use all the disable options above, you just need to add an exclamation mark before autoprefixer.
+
+For example: 
+
+```css
+/* ! autoprefixer: off */
+@supports (transition: all) {
+    /* ! autoprefixer: on */
+    a {
+        /* ! autoprefixer: off */
+    }
+}
+```
+
 ## Options
 
 Function `autoprefixer(options)` returns new PostCSS plugin.


### PR DESCRIPTION
New PR for documentation disabling Autoprefixer in Sass/SCSS.

Previous PR: https://github.com/postcss/autoprefixer/pull/785