### PR TITLE
Add prefix to text-decoration-skip in IOS

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -333,7 +333,7 @@ feature decoration, (browsers) ->
           browsers: browsers
           feature: 'text-decoration'
 
-feature decoration, match: /x.*#3/, (browsers) ->
+feature decoration, match: /x.*#[23]/, (browsers) ->
   prefix 'text-decoration-skip',
           browsers: browsers
           feature: 'text-decoration'


### PR DESCRIPTION
For the sake of completeness and to make one more test pass on our way to make https://github.com/cssinjs/css-vendor comply with autoprefixer :-)