### PR TITLE
Clip Path should derive from css-clip-path feature

### DIFF
--- a/data/prefixes.coffee
+++ b/data/prefixes.coffee
@@ -353,11 +353,17 @@ feature require('caniuse-db/features-json/css-masks.json'), (browsers) ->
          'mask-border-source',
           browsers: browsers
           feature: 'css-masks'
-  prefix 'clip-path', 'mask', 'mask-position', 'mask-size',
+  prefix 'mask', 'mask-position', 'mask-size',
          'mask-border', 'mask-border-outset', 'mask-border-width',
          'mask-border-slice',
           browsers: browsers
           feature: 'css-masks'
+
+# CSS clip-path property
+feature require('caniuse-db/features-json/css-clip-path.json'), (browsers) ->
+  prefix 'clip-path',
+          browsers: browsers
+          feature: 'css-clip-path'
 
 # Fragmented Borders and Backgrounds
 boxdecorbreak = require('caniuse-db/features-json/css-boxdecorationbreak.json')


### PR DESCRIPTION
I think clip-path should derive from `caniuse-db/features-json/css-clip-path.json` instead of `caniuse-db/features-json/css-masks.json`.
This was a real quick patch. Please check for correctness.