### PR TITLE
Fix: add min/max-content test case for grid

### DIFF
--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -39,3 +39,11 @@
         display: grid;
     }
 }
+
+.min-max-content {
+    grid-template-columns: min-content max-content;
+}
+
+.fit-content {
+    grid-template-columns: min-content max-content fit-content(500px);
+}

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -58,3 +58,15 @@
         display: grid;
     }
 }
+
+.min-max-content {
+    -ms-grid-columns: min-content max-content;
+    grid-template-columns: -webkit-min-content -webkit-max-content;
+    grid-template-columns: min-content max-content;
+}
+
+.fit-content {
+    -ms-grid-columns: min-content max-content fit-content(500px);
+    grid-template-columns: -webkit-min-content -webkit-max-content fit-content(500px);
+    grid-template-columns: min-content max-content fit-content(500px);
+}


### PR DESCRIPTION
I think IE not support `fit-content()`, so the PR may need to be adjusted.

https://msdn.microsoft.com/en-us/library/hh772246(v=vs.85).aspx