### PR TITLE
Fix postcss-cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ You can use the [postcss-cli] to run Autoprefixer from CLI:
 
 ```sh
 npm install --global postcss-cli autoprefixer
-postcss --use autoprefixer *.css -d build/
+postcss *.css --use autoprefixer -d build/
 ```
 
 See `postcss -h` for help.


### PR DESCRIPTION
The old example won't work in postcss-cli v3, since `--use` takes an array.