### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/resolution.js
+++ b/lib/resolution.js
@@ -71,7 +71,7 @@ class Resolution extends Prefixer {
                     ) {
                         continue;
                     }
-                    
+
                     const processed = query.replace(regexp, str => {
                         const parts = str.match(split);
                         return this.prefixQuery(

--- a/lib/resolution.js
+++ b/lib/resolution.js
@@ -70,19 +70,19 @@ class Resolution extends Prefixer {
                         rule.params.indexOf('dpi') !== -1
                     ) {
                         continue;
-                    } else {
-                        const processed = query.replace(regexp, str => {
-                            const parts = str.match(split);
-                            return this.prefixQuery(
-                                prefix,
-                                parts[1],
-                                parts[2],
-                                parts[3],
-                                parts[4]
-                            );
-                        });
-                        prefixed.push(processed);
                     }
+                    
+                    const processed = query.replace(regexp, str => {
+                        const parts = str.match(split);
+                        return this.prefixQuery(
+                            prefix,
+                            parts[1],
+                            parts[2],
+                            parts[3],
+                            parts[4]
+                        );
+                    });
+                    prefixed.push(processed);
                 }
                 prefixed.push(query);
             }


### PR DESCRIPTION
Removes the else after the continue (inside a for loop).
Result: less indentation, less code, more readable, easier to follow