### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/brackets.js
+++ b/lib/brackets.js
@@ -15,15 +15,17 @@ const brackets = {
                 current = [''];
                 last(stack).push(current);
                 stack.push(current);
+                continue;
+            }
 
-            } else if (sym === ')') {
+            if (sym === ')') {
                 stack.pop();
                 current = last(stack);
                 current.push('');
-
-            } else {
-                current[current.length - 1] += sym;
+                continue;
             }
+
+            current[current.length - 1] += sym;
         }
 
         return stack[0];
@@ -37,9 +39,10 @@ const brackets = {
         for (const i of ast) {
             if (typeof i === 'object') {
                 result += `(${brackets.stringify(i)})`;
-            } else {
-                result += i;
+                continue;
             }
+
+            result += i;
         }
         return result;
     }


### PR DESCRIPTION
Uses early returns (continue inside loops) so else statements are made redundant.
Result: less indentation, less code, more readable, easier to follow