### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/value.js
+++ b/lib/value.js
@@ -93,9 +93,9 @@ class Value extends Prefixer {
     value(decl) {
         if (decl.raws.value && decl.raws.value.value === decl.value) {
             return decl.raws.value.raw;
+        } else {
+            return decl.value;
         }
-
-        return decl.value;
     }
 
     /**

--- a/lib/value.js
+++ b/lib/value.js
@@ -23,26 +23,37 @@ class Value extends Prefixer {
             let item;
             const propPrefix = vendor.prefix(prop);
 
+            if (propPrefix === '-pie-') {
+                continue;
+            }
+            
             if (propPrefix === prefix) {
                 item = decl.value = value;
-            } else if (propPrefix === '-pie-') {
+                result.push(item);
                 continue;
-            } else {
-                const prefixed = prefixes.prefixed(prop, prefix);
-                const rule = decl.parent;
-                if (rule.every(i => i.prop !== prefixed)) {
-                    const trimmed = value.replace(/\s+/, ' ');
-                    const already = rule.some(
-                        i => i.prop === decl.prop &&
-                             i.value.replace(/\s+/, ' ') === trimmed
-                    );
-
-                    if (!already) {
-                        const cloned = this.clone(decl, { value });
-                        item = decl.parent.insertBefore(decl, cloned);
-                    }
-                }
             }
+            
+            const prefixed = prefixes.prefixed(prop, prefix);
+            const rule = decl.parent;
+
+            if (!rule.every(i => i.prop !== prefixed)) {
+                result.push(item);
+                continue;
+            }
+
+            const trimmed = value.replace(/\s+/, ' ');
+            const already = rule.some(
+                i => i.prop === decl.prop &&
+                     i.value.replace(/\s+/, ' ') === trimmed
+            );
+
+            if (already) {
+                result.push(item);
+                continue;
+            }
+
+            const cloned = this.clone(decl, { value });
+            item = decl.parent.insertBefore(decl, cloned);
 
             result.push(item);
         }
@@ -55,11 +66,11 @@ class Value extends Prefixer {
      */
     check(decl) {
         const value = decl.value;
-        if (value.indexOf(this.name) !== -1) {
-            return !!value.match(this.regexp());
-        } else {
+        if (value.indexOf(this.name) == -1) {
             return false;
         }
+
+        return !!value.match(this.regexp());
     }
 
     /**
@@ -82,9 +93,9 @@ class Value extends Prefixer {
     value(decl) {
         if (decl.raws.value && decl.raws.value.value === decl.value) {
             return decl.raws.value.raw;
-        } else {
-            return decl.value;
         }
+
+        return decl.value;
     }
 
     /**

--- a/lib/value.js
+++ b/lib/value.js
@@ -26,13 +26,13 @@ class Value extends Prefixer {
             if (propPrefix === '-pie-') {
                 continue;
             }
-            
+
             if (propPrefix === prefix) {
                 item = decl.value = value;
                 result.push(item);
                 continue;
             }
-            
+
             const prefixed = prefixes.prefixed(prop, prefix);
             const rule = decl.parent;
 
@@ -66,7 +66,7 @@ class Value extends Prefixer {
      */
     check(decl) {
         const value = decl.value;
-        if (value.indexOf(this.name) == -1) {
+        if (value.indexOf(this.name) === -1) {
             return false;
         }
 


### PR DESCRIPTION
This one has a bit more refactoring going on, so you will need a good test run n this. Or drop it, if you don't think it is worth it :)

It would clean stuff up a bit to extract a large part of the code in the for loop to a separate getItem method.
That way you can do early returns more easily and only need one result.push(item);

Something like:
``` 
                item = this.getItem(propPrefix, decl);
                result.push(item);
```