### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/transition.js
+++ b/lib/transition.js
@@ -117,29 +117,31 @@ class Transition {
      * Show transition-property warning
      */
     checkForWarning(result, decl) {
-        if (decl.prop === 'transition-property') {
-            decl.parent.each((i) => {
-                if (i.type !== 'decl') {
-                    return undefined;
-                }
-                if (i.prop.indexOf('transition-') !== 0) {
-                    return undefined;
-                }
-                if (i.prop === 'transition-property') {
-                    return undefined;
-                }
-
-                if (list.comma(i.value).length > 1) {
-                    decl.warn(result,
-                        'Replace transition-property to transition, ' +
-                        'because Autoprefixer could not support ' +
-                        'any cases of transition-property ' +
-                        'and other transition-*'
-                    );
-                }
-                return false;
-            });
+        if (decl.prop !== 'transition-property') {
+            return;
         }
+
+        decl.parent.each((i) => {
+            if (i.type !== 'decl') {
+                return undefined;
+            }
+            if (i.prop.indexOf('transition-') !== 0) {
+                return undefined;
+            }
+            if (i.prop === 'transition-property') {
+                return undefined;
+            }
+
+            if (list.comma(i.value).length > 1) {
+                decl.warn(result,
+                    'Replace transition-property to transition, ' +
+                    'because Autoprefixer could not support ' +
+                    'any cases of transition-property ' +
+                    'and other transition-*'
+                );
+            }
+            return false;
+        });
     }
 
     /**
@@ -173,9 +175,10 @@ class Transition {
 
         if (double || smaller) {
             decl.remove();
-        } else {
-            decl.value = value;
+            return;
         }
+
+        decl.value = value;
     }
 
     /**
@@ -290,7 +293,9 @@ class Transition {
         if (prop.indexOf('flex') !== -1 || other.indexOf(prop) !== -1) {
             if (this.prefixes.options.flexbox === false) {
                 return true;
-            } else if (this.prefixes.options.flexbox === 'no-2009') {
+            }
+
+            if (this.prefixes.options.flexbox === 'no-2009') {
                 return prefix.indexOf('2009') !== -1;
             }
         }


### PR DESCRIPTION
Removes redundant elses after early returns.
Result: less indentation, more readable, easier to follow