### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/supports.js
+++ b/lib/supports.js
@@ -162,15 +162,18 @@ class Supports {
             ) {
                 if (this.toRemove(nodes[i][0], all)) {
                     nodes.splice(i, 2);
-                } else {
-                    i += 2;
+                    continue;
                 }
-            } else {
-                if (typeof nodes[i] === 'object') {
-                    nodes[i] = this.remove(nodes[i], all);
-                }
-                i += 1;
+
+                i += 2;
+                continue;
             }
+
+            if (typeof nodes[i] === 'object') {
+                nodes[i] = this.remove(nodes[i], all);
+            }
+
+            i += 1;
         }
         return nodes;
     }
@@ -180,15 +183,15 @@ class Supports {
      */
     cleanBrackets(nodes) {
         return nodes.map(i => {
-            if (typeof i === 'object') {
-                if (i.length === 1 && typeof i[0] === 'object') {
-                    return this.cleanBrackets(i[0]);
-                } else {
-                    return this.cleanBrackets(i);
-                }
-            } else {
+            if (typeof i !== 'object') {
                 return i;
             }
+
+            if (i.length === 1 && typeof i[0] === 'object') {
+                return this.cleanBrackets(i[0]);
+            }
+
+            return this.cleanBrackets(i);
         });
     }
 
@@ -209,16 +212,16 @@ class Supports {
      * Compress value functions into a string nodes
      */
     normalize(nodes) {
-        if (typeof nodes === 'object') {
-            nodes = nodes.filter(i => i !== '');
-            if (typeof nodes[0] === 'string' && nodes[0].indexOf(':') !== -1) {
-                return [brackets.stringify(nodes)];
-            } else {
-                return nodes.map(i => this.normalize(i));
-            }
-        } else {
+        if (typeof nodes !== 'object') {
             return nodes;
         }
+
+        nodes = nodes.filter(i => i !== '');
+        if (typeof nodes[0] === 'string' && nodes[0].indexOf(':') !== -1) {
+            return [brackets.stringify(nodes)];
+        }
+
+        return nodes.map(i => this.normalize(i));
     }
 
     /**
@@ -230,14 +233,16 @@ class Supports {
                 const prefixed = this.prefixed(i[0]);
                 if (prefixed.length > 1) {
                     return this.convert(prefixed);
-                } else {
-                    return i;
                 }
-            } else if (typeof i === 'object') {
-                return this.add(i, all);
-            } else {
+
                 return i;
             }
+
+            if (typeof i === 'object') {
+                return this.add(i, all);
+            }
+
+            return i;
         });
     }
 


### PR DESCRIPTION
Uses early returns (and continues inside loops) so else statements are made redundant.
Result: less indentation, less code, more readable, easier to follow

PS: Quite a few more complex changes (flipping logic), so testing if this doesn't alter functionality is a good idea :)