### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/selector.js
+++ b/lib/selector.js
@@ -16,9 +16,9 @@ class Selector extends Prefixer {
     check(rule) {
         if (rule.selector.indexOf(this.name) !== -1) {
             return !!rule.selector.match(this.regexp());
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Removes redundant elses after early returns.
Result: less indentation, more readable, easier to follow