### PR TITLE
[Refactor] Removes redundant else structures

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -270,19 +270,23 @@ class Processor {
 
             // Values
             for (const checker of this.prefixes.values('remove', unprefixed)) {
-                if (checker.check(decl.value)) {
-                    unprefixed = checker.unprefixed;
-                    const notHack = this.prefixes.group(decl).down(
-                        other => other.value.indexOf(unprefixed) !== -1
-                    );
+                if (!checker.check(decl.value)) {
+                    continue;
+                }
 
-                    if (notHack) {
-                        rule.removeChild(i);
-                        return;
-                    } else if (checker.clean) {
-                        checker.clean(decl);
-                        return;
-                    }
+                unprefixed = checker.unprefixed;
+                const notHack = this.prefixes.group(decl).down(
+                    other => other.value.indexOf(unprefixed) !== -1
+                );
+
+                if (notHack) {
+                    rule.removeChild(i);
+                    return;
+                }
+
+                if (checker.clean) {
+                    checker.clean(decl);
+                    return;
                 }
             }
         });
@@ -347,7 +351,9 @@ class Processor {
     disabled(node) {
         if (node._autoprefixerDisabled !== undefined) {
             return node._autoprefixerDisabled;
-        } else if (node.nodes) {
+        }
+
+        if (node.nodes) {
             let status = undefined;
             node.each(i => {
                 if (i.type !== 'comment') {
@@ -372,15 +378,15 @@ class Processor {
 
             node._autoprefixerDisabled = result;
             return node._autoprefixerDisabled;
+        }
 
-        } else if (node.parent) {
+        if (node.parent) {
             node._autoprefixerDisabled = this.disabled(node.parent);
             return node._autoprefixerDisabled;
-
-        } else {
-            // unknown state
-            return false;
         }
+
+        // unknown state
+        return false;
     }
 
     /**
@@ -420,14 +426,19 @@ class Processor {
      */
     displayType(decl) {
         for (const i of decl.parent.nodes) {
-            if (i.prop === 'display') {
-                if (i.value.indexOf('flex') !== -1) {
-                    return 'flex';
-                } else if (i.value.indexOf('grid') !== -1) {
-                    return 'grid';
-                }
+            if (i.prop !== 'display') {
+                continue;
+            }
+
+            if (i.value.indexOf('flex') !== -1) {
+                return 'flex';
+            }
+
+            if (i.value.indexOf('grid') !== -1) {
+                return 'grid';
             }
         }
+
         return false;
     }
 


### PR DESCRIPTION
Removes redundant elses after early returns.
Result: less indentation, more readable, easier to follow