### PR TITLE
Bugfix reuse of global RegEx object.

### DIFF
--- a/lib/hacks/gradient.js
+++ b/lib/hacks/gradient.js
@@ -125,6 +125,10 @@ class Gradient extends Value {
         if (params[0].value === 'to') {
             return params;
         }
+        /* reset the search index of the global regex object, otherwise the next use 
+         * will start the search for a match at the index where the search ended this time.
+         */
+        isDirection.lastIndex = 0;
         if (!isDirection.test(params[0].value)) {
             return params;
         }


### PR DESCRIPTION
When the same global regex object is used, you need to reset the lastIndex property. I have not yet looked at all the other hacks for additional occurrences of this bug.

Currently every other linear-gradient appearing in your css is converted into an invalid form.

Take `foo.css`
```css
.a {                                                                                                
    background: linear-gradient(top,#fff 0,#ff3300 3%,#ff9900 100%);                                
}

#a {
    background: #fff;
}
         
.b {                                                                                                
    background: linear-gradient(top,#fff 0,#ff3300 3%,#ff9900 100%);                                
} 

.c {                                                                                                
    background: linear-gradient(top,#fff 0,#ff3300 3%,#ff9900 100%);                                
}

.d {                                                                                                
    background: linear-gradient(top,#fff 0,#ff3300 3%,#ff9900 100%);                                
}        
```   

`cat foo.css | postcss --no-map  -u autoprefixer`

See the generated CSS where every other linear-gradient rule has an extra `from(top)` token appearing (which is invalid CSS, and causes FireFox to not accept the rule)

```css
.a {
    background: -webkit-gradient(linear,left top, left bottom,color-stop(0, #fff),color-stop(3%, #3d373d),to(#141214));
    background: linear-gradient(top,#fff 0,#3d373d 3%,#141214 100%);
}

#a {
    background: #fff;
}

/* NOTE the invalid from(top) that appears here */
.b {
    background: -webkit-gradient(linear,left top, left bottom,from(top),color-stop(0, #fff),color-stop(3%, #3d373d),to(#141214));
    background: linear-gradient(top,#fff 0,#3d373d 3%,#141214 100%);
}

.c {
    background: -webkit-gradient(linear,left top, left bottom,color-stop(0, #fff),color-stop(3%, #3d373d),to(#141214));
    background: linear-gradient(top,#fff 0,#3d373d 3%,#141214 100%);
}

/* NOTE the invalid from(top) that appears here */
.d {
    background: -webkit-gradient(linear,left top, left bottom,from(top),color-stop(0, #fff),color-stop(3%, #3d373d),to(#141214));
    background: linear-gradient(top,#fff 0,#3d373d 3%,#141214 100%);
}
```                                                                                      