### PR TITLE
Provide a default file path for info() output

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -93,6 +93,9 @@ module.exports = postcss.plugin('autoprefixer', (...reqs) => {
     plugin.options = options;
 
     plugin.info = function (opts) {
+        opts = opts || {};
+        opts.from = opts.from || process.cwd();
+
         return require('./info')(loadPrefixes(opts));
     };
 


### PR DESCRIPTION
Fixes https://github.com/postcss/autoprefixer/issues/931.

This provides a default file path when invoking the `info()` method on the plugin. This allows the plugin to, by default, retrieve the local config from the file system. If you pass a hash to `info`, then that will be used without modification.