### PR TITLE
Reduce size & make animation check a little faster

### DIFF
--- a/lib/hacks/animation.js
+++ b/lib/hacks/animation.js
@@ -8,17 +8,10 @@ class Animation extends Declaration {
      * Don’t add prefixes for modern values.
      */
     check(decl) {
-        let found = false;
-        decl.value.split(/\s+/).forEach(i => {
+        return !decl.value.split(/\s+/).some(i => {
             const lower = i.toLowerCase();
-            if (lower === 'reverse' || lower === 'alternate-reverse') {
-                found = true;
-                return false;
-            } else {
-                return true;
-            }
+            return lower === 'reverse' || lower === 'alternate-reverse';
         });
-        return !found;
     }
 
 }


### PR DESCRIPTION
Array#some stops executing once it finds a matching element which makes the
code a little faster than using Array#forEach in some cases. It's also smaller.

Ref b8cbd673b81360214c3bb4d597b83639aca0027f
Ref ai/autoprefixer-rails#128