### PR TITLE
Support for classes in IE 10 and below

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "browserify": "^14.5.0",
@@ -105,6 +106,12 @@
         "transform-class-properties",
         {
           "spec": true
+        }
+      ],
+      [
+        "transform-es2015-classes",
+        {
+          "loose": true
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-eslint": "^8.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
+    "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "browserify": "^14.5.0",
@@ -102,6 +103,9 @@
       ]
     ],
     "plugins": [
+      [
+        "transform-proto-to-assign"
+      ],
       [
         "transform-class-properties",
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,6 +767,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-proto-to-assign@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.26.0.tgz#c493e24a62749a44f7ede96506c0cb3a1891f67b"
+  dependencies:
+    babel-runtime "^6.26.0"
+    lodash "^4.17.4"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,7 +613,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:


### PR DESCRIPTION
To support ES6 classes in IE 10 and below, according to Babel [docs](https://babeljs.io/docs/usage/caveats/#internet-explorer-classes-10-and-below-) projects need to use `babel-plugin-transform-es2015-classes` (https://www.npmjs.com/package/babel-plugin-transform-proto-to-assign). So, I added it on this PR.