### PR TITLE
Readme stale counts removed, wording improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ please create an issue on GitHub.
 
 ### Features
 
-There are 4 plugin’s options to disable some Autoprefixer features.
+You can use these plugin options to disable some of the Autoprefixer's features.
 
 * `supports: false` will disable `@supports` parameters prefixing.
 * `flexbox: false` will disable flexbox properties prefixing.
@@ -580,7 +580,7 @@ See [PostCSS API] for plugin usage documentation.
 autoprefixer({ cascade: false })
 ```
 
-There are 8 options:
+Available options are:
 
 * `browsers` (array): list of browsers query (like `last 2 versions`),
   which are supported in your project. We recommend to use `browserslist`


### PR DESCRIPTION
Readme uses absolute counts which seem to be stale. `Features` section lists 3 options instead of 4 and the `Options` sections lists 9 instead of 8.

Absolute counts removed and the wording improved in terms of grammar.