### PR TITLE
Add support for color-adjust property

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -779,3 +779,12 @@ f(over, { match: /a #1/ }, browsers =>
         browsers
     })
 );
+
+
+// CSS color-adjust
+f(require('caniuse-lite/data/features/css-color-adjust.js'), browsers =>
+    prefix(['color-adjust'], {
+        feature: 'css-color-adjust',
+        browsers
+    })
+);

--- a/lib/hacks/color-adjust.js
+++ b/lib/hacks/color-adjust.js
@@ -1,0 +1,22 @@
+const Declaration = require('../declaration');
+
+class ColorAdjust extends Declaration {
+
+    static names = ['color-adjust'];
+
+    /**
+     * Change property name for -webkit browsers
+     */
+    prefixed(prop, prefix) {
+        return prefix + 'print-color-adjust';
+    }
+
+    /**
+     * Return property name by spec
+     */
+    normalize() {
+        return 'color-adjust';
+    }
+}
+
+module.exports = ColorAdjust;

--- a/lib/hacks/color-adjust.js
+++ b/lib/hacks/color-adjust.js
@@ -2,7 +2,7 @@ const Declaration = require('../declaration');
 
 class ColorAdjust extends Declaration {
 
-    static names = ['color-adjust'];
+    static names = ['color-adjust', 'print-color-adjust'];
 
     /**
      * Change property name for -webkit browsers

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -51,6 +51,7 @@ Declaration.hack(require('./hacks/grid-column-align'));
 Declaration.hack(require('./hacks/overscroll-behavior'));
 Declaration.hack(require('./hacks/grid-template-areas'));
 Declaration.hack(require('./hacks/text-emphasis-position'));
+Declaration.hack(require('./hacks/color-adjust'));
 
 Value.hack(require('./hacks/gradient'));
 Value.hack(require('./hacks/intrinsic'));

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -144,7 +144,7 @@ const COMMONS = [
     'advanced-filter', 'element', 'image-set', 'image-rendering',
     'mask-border', 'writing-mode', 'cross-fade', 'gradient-fix',
     'text-emphasis-position', 'grid', 'grid-area', 'grid-template',
-    'grid-template-areas'
+    'grid-template-areas', 'color-adjust'
 ];
 
 it('throws on wrong options', () => {
@@ -422,6 +422,7 @@ describe('hacks', () => {
     it('supports text-decoration',      () => test('text-decoration'));
     it('ignores modern direction',      () => test('animation'));
     it('supports overscroll-behavior',  () => test('overscroll-behavior'));
+    it('supports color-adjust',         () => test('color-adjust'));
 
     it('supports appearance for IE', () => {
         const instance = autoprefixer({ browsers: 'Edge 15' });

--- a/test/cases/color-adjust.css
+++ b/test/cases/color-adjust.css
@@ -1,0 +1,7 @@
+.a {
+    color-adjust: exact;
+}
+
+.b {
+    color-adjust: economy;
+}

--- a/test/cases/color-adjust.out.css
+++ b/test/cases/color-adjust.out.css
@@ -1,0 +1,9 @@
+.a {
+    -webkit-print-color-adjust: exact;
+            color-adjust: exact;
+}
+
+.b {
+    -webkit-print-color-adjust: economy;
+            color-adjust: economy;
+}


### PR DESCRIPTION
Hi @ai, here is my try.
I don't think it differs a lot from other's PRs, except declarations indentation in CSS test cases and added 'print-color-adjust' to names array.
Also, I created a stub for caniuse-lite/data/features/css-color-adjust.js and run green jest tests against it.