### PR TITLE
Update examples for Browserslist w/ best practises

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ a {
 ## Browsers
 
 Autoprefixer uses [Browserslist], so you can specify the browsers
-you want to target in your project by queries like `last 2 versions`
-or `> 5%`.
+you want to target in your project by queries like `last 2 versions, not dead`
+or `> 5%` (see [Best Practises](https://github.com/browserslist/browserslist#best-practices)).
 
 The best way to provide browsers is `.browserslistrc` config
 or `package.json` with `browserslist` key. Put it in your project root.
@@ -555,7 +555,7 @@ autoprefixer({ cascade: false })
 
 Available options are:
 
-* `browsers` (array): list of browsers query (like `last 2 versions`),
+* `browsers` (array): list of browsers query (like `last 2 versions, not dead`),
   which are supported in your project. We recommend to use `browserslist`
   config or `browserslist` key in `package.json`, rather than this option
   to share browsers with other tools. See [Browserslist docs] for available


### PR DESCRIPTION
It came to my attention recently that using [`last 2 versions` may be considered harmful](https://jamie.build/last-2-versions). This specific article uses Babel as an example, but I also remembered that autoprefixer uses Browserlist. I was erroneously thinking that by using `last 2 versions` I would be targetting only most recent browsers, but I learned that it also targets "dead" browsers.

Browserlist's repo [recently added a best practise section](https://github.com/browserslist/browserslist/commit/019cb298c433dcd797d0538df8027fa2b2effc25) mentioning this.

I was thinking it would be a good idea to also update the examples here.