### PR TITLE
fix Processor.disabled(): check if node has parent before get prev()

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -345,11 +345,13 @@ class Processor {
             return node._autoprefixerDisabled;
         }
 
-        const prev = node.prev();
-        if (prev && prev.type === 'comment' && IGNORE_NEXT.test(prev.text)) {
-            node._autoprefixerDisabled = true;
-            node._autoprefixerSelfDisabled = true;
-            return true;
+        if (node.parent) {
+            const prev = node.prev();
+            if (prev && prev.type === 'comment' && IGNORE_NEXT.test(prev.text)) {
+                node._autoprefixerDisabled = true;
+                node._autoprefixerSelfDisabled = true;
+                return true;
+            }
         }
 
         let value = null;


### PR DESCRIPTION
If not do so, there are fatal errors, at least on my projects...