### PR TITLE
Show warning if grid-area has a non-unique identifier (fixes #1038)

### DIFF
--- a/lib/hacks/grid-area.js
+++ b/lib/hacks/grid-area.js
@@ -7,7 +7,7 @@ class GridArea extends Declaration {
     /**
      * Translate grid-area to separate -ms- prefixed properties
      */
-    insert (decl, prefix, prefixes, result) {
+    insert (decl, prefix, prefixes) {
       if (prefix !== '-ms-') return super.insert(decl, prefix, prefixes)
 
       const values = utils.parse(decl)
@@ -23,13 +23,6 @@ class GridArea extends Declaration {
       ].forEach(([prop, value]) => {
         utils.insertDecl(decl, prop, value)
       })
-
-      const nonUniqueIdentifiers = utils.findNonUniqueAreaIdentifiers(decl)
-      if (nonUniqueIdentifiers.length > 0) {
-        nonUniqueIdentifiers.forEach(area => {
-          decl.warn(result, `grid-area identifier is not unique: ${ area }`)
-        })
-      }
 
       return undefined
     }

--- a/lib/hacks/grid-area.js
+++ b/lib/hacks/grid-area.js
@@ -7,7 +7,7 @@ class GridArea extends Declaration {
     /**
      * Translate grid-area to separate -ms- prefixed properties
      */
-    insert (decl, prefix, prefixes) {
+    insert (decl, prefix, prefixes, result) {
       if (prefix !== '-ms-') return super.insert(decl, prefix, prefixes)
 
       const values = utils.parse(decl)
@@ -23,6 +23,13 @@ class GridArea extends Declaration {
       ].forEach(([prop, value]) => {
         utils.insertDecl(decl, prop, value)
       })
+
+      const nonUniqueIdentifiers = utils.findNonUniqueAreaIdentifiers(decl)
+      if (nonUniqueIdentifiers.length > 0) {
+        nonUniqueIdentifiers.forEach(area => {
+          decl.warn(result, `grid-area identifier is not unique: ${ area }`)
+        })
+      }
 
       return undefined
     }

--- a/lib/hacks/grid-template-areas.js
+++ b/lib/hacks/grid-template-areas.js
@@ -5,7 +5,8 @@ const {
   prefixTrackProp,
   prefixTrackValue,
   getGridGap,
-  warnGridGap
+  warnGridGap,
+  warnDuplicateNames
 } = require('./grid-utils')
 
 function getGridRows (tpl) {
@@ -69,6 +70,9 @@ class GridTemplateAreas extends Declaration {
         decl,
         result
       })
+
+      // warn if grid-template-areas has a duplicate area name
+      warnDuplicateNames({ decl, result })
 
       const areas = parseGridAreas({
         rows: gridRows,

--- a/lib/hacks/grid-template.js
+++ b/lib/hacks/grid-template.js
@@ -3,7 +3,8 @@ const {
   parseTemplate,
   insertAreas,
   getGridGap,
-  warnGridGap
+  warnGridGap,
+  warnDuplicateNames
 } = require('./grid-utils')
 
 class GridTemplate extends Declaration {
@@ -41,6 +42,9 @@ class GridTemplate extends Declaration {
         decl,
         result
       })
+
+      // warn if grid-template has a duplicate area name
+      warnDuplicateNames({ decl, result })
 
       if ((hasRows && hasColumns) || hasAreas) {
         decl.cloneBefore({

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -1,5 +1,4 @@
 const parser = require('postcss-value-parser')
-const regexp = require('../utils').regexp
 const list = require('postcss').list
 
 function convert (value) {
@@ -142,115 +141,81 @@ function prefixTrackValue ({ value, gap }) {
 }
 
 /**
- * Check if css identifier is valid
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident
- * @param String [identifier]
- * @return RegExp
- */
-function isValidCssIdentifier (identifier) {
-  const h = '[0-9a-f]'
-  const unicode = `\\\\${ h }{1,6}(\\r\\n|[ \\t\\r\\n\\f])?`
-  const escape = `(${ unicode }|\\\\[^\\r\\n\\f0-9a-f])`
-  const nonascii = `[\\240-\\377]`
-  const nmchar = `([_a-z0-9-]|${ nonascii }|${ escape })`
-  const nmstart = `([_a-z]|${ nonascii }|${ escape })`
-  const identifierRegexp = `-?${ nmstart }${ nmchar }*`
-
-  return new RegExp(identifierRegexp).test(identifier)
-}
-
-/**
- * Parse grid-area identifiers
- * @param Declaration [decl]
- * @return Array<String>
- */
-function parseGridAreaIdentifiers (decl) {
-  const parsed = parser(decl.value)
-  const identifiers = []
-  parsed.walk(({ value, type }) => {
-    if (type === 'word' && value !== 'span' && isValidCssIdentifier(value)) {
-      identifiers.push(value)
-    }
-  })
-  return identifiers
-}
-
-/**
- * Parse all grid-template(-areas) strings and return an array
+ * Parse grid areas from declaration
  * @param Declaration [decl]
  * @return Array<String>
  */
 function parseGridTemplateStrings (decl) {
-  const result = []
-  decl.root().walkDecls(/grid-template(-areas)?$/, d => {
-    const media = getParentMedia(d.parent)
-    if (!media) {
-      const gap = getGridGap(decl)
-      const template = parseTemplate({ decl: d, gap })
-      const keys = Object.keys(template.areas)
-      if (keys.length > 0) {
-        result.push(keys.join(' '))
-      }
-    }
-  })
-  return result
+  const template = parseTemplate({ decl, gap: getGridGap(decl) })
+  return Object.keys(template.areas)
 }
 
 /**
- * Find non-unique grid-area identifiers from declaration
- * @param Declaration [decl]
- * @return Array<String>
+ * Walk through every grid-template(-areas)
+ * declaration and try to find non-unique area names (duplicates)
+ * @param  {Declaration} decl
+ * @param  {Result} result
+ * @return {void}
  */
-function findNonUniqueAreaIdentifiers (decl) {
-  const parent = decl.parent
-  const media = getParentMedia(parent)
+function warnDuplicateNames ({ decl, result }) {
+  const rule = decl.parent
+  const inMediaRule = !!getParentMedia(rule)
+  const areas = parseGridTemplateStrings(decl)
   const root = decl.root()
 
-  if (media) {
-    // break selector into list (e.g. ['.foo', '.bar'])
-    const selectorList = list.comma(parent.selector)
-    let shouldWarn = true
-    // for every selector string
-    for (const sel of selectorList) {
-      // walk through every rule
-      root.walkRules(rule => {
-        const isEqual = parent.toString() === rule.toString()
-        // if selectors are the same && we're not on the same rule
-        if (rule.selector === sel && !isEqual) {
-          rule.walkDecls('grid-area', d => {
-            // compare declarations
-            if (d.value === decl.value) {
-              shouldWarn = false
-            }
-          })
-        }
-      })
-    }
-    if (!shouldWarn) {
-      return false
-    }
+  // stop if no areas found
+  if (areas.length === 0) {
+    return false
   }
 
-  const customIdentifiers = parseGridAreaIdentifiers(decl)
-  if (customIdentifiers.length > 0) {
-    // parse grid-template strings from all rules
-    const gridStrings = parseGridTemplateStrings(decl)
+  root.walkDecls(/grid-template(-areas)?$/g, d => {
+    const nodeRule = d.parent
+    const nodeRuleMedia = getParentMedia(nodeRule)
+    const isEqual = rule.toString() === nodeRule.toString()
+    const foundAreas = parseGridTemplateStrings(d)
+    const maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
+    const isLookingDown = root.index(rule) < maxIndex
 
-    // find non-unique items by filtering
-    const result = customIdentifiers.filter(identifier => {
-      let found = false
-      return gridStrings.some((str, index) => {
-        if (regexp(identifier, false).test(str) && found && index > 0) {
+    // abort if we outside media rule and walking below our rule
+    // (we need to check ONLY the rules that are above)
+    if (!inMediaRule && isLookingDown) {
+      return false
+    }
+
+    // abort if we're in the same rule
+    if (isEqual) {
+      return false
+    }
+
+    // if we're inside media rule, we need to compare selectors
+    if (inMediaRule) {
+      const selectors = list.comma(nodeRule.selector)
+      const selectorIsFound = selectors.some(sel => {
+        if (sel === rule.selector) {
+          // compare selectors as a comma list
           return true
-        } else if (regexp(identifier, false).test(str)) {
-          found = true
+        } else if (nodeRule.selector === rule.selector) {
+          // compare selectors as a whole (e.g. ".i, .j" === ".i, .j")
+          return true
         }
         return false
       })
-    })
-    return result
-  }
-  return false
+
+      // stop walking if we found the selector
+      if (selectorIsFound) {
+        return false
+      }
+    }
+
+    const duplicates = areas.filter(area => foundAreas.includes(area))
+    if (duplicates.length > 0) {
+      const word = duplicates.length > 1 ? 'names' : 'name'
+      decl.warn(result, `duplicate area ${ word }: ${ duplicates.join(', ') }`)
+      return false
+    }
+    return undefined
+  })
+  return undefined
 }
 
 // Parse grid-template-areas
@@ -522,5 +487,5 @@ module.exports = {
   prefixTrackValue,
   getGridGap,
   warnGridGap,
-  findNonUniqueAreaIdentifiers
+  warnDuplicateNames
 }

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -176,6 +176,11 @@ function warnDuplicateNames ({ decl, result }) {
     const maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
     const isLookingDown = root.index(rule) < maxIndex
 
+    // skip node if no grid areas is found
+    if (foundAreas.length === 0) {
+      return true
+    }
+
     // abort if we outside media rule and walking below our rule
     // (we need to check ONLY the rules that are above)
     if (!inMediaRule && isLookingDown) {

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -1,4 +1,5 @@
 const parser = require('postcss-value-parser')
+const regexp = require('../utils').regexp
 
 function convert (value) {
   if (value &&
@@ -137,6 +138,93 @@ function prefixTrackValue ({ value, gap }) {
     }, [])
 
   return parser.stringify(result)
+}
+
+/**
+ * Check if css identifier is valid
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident
+ * @param String [identifier]
+ * @return RegExp
+ */
+function isValidCssIdentifier (identifier) {
+  const h = '[0-9a-f]'
+  const unicode = `\\\\${ h }{1,6}(\\r\\n|[ \\t\\r\\n\\f])?`
+  const escape = `(${ unicode }|\\\\[^\\r\\n\\f0-9a-f])`
+  const nonascii = `[\\240-\\377]`
+  const nmchar = `([_a-z0-9-]|${ nonascii }|${ escape })`
+  const nmstart = `([_a-z]|${ nonascii }|${ escape })`
+  const identifierRegexp = `-?${ nmstart }${ nmchar }*`
+
+  return new RegExp(identifierRegexp).test(identifier)
+}
+
+/**
+ * Parse grid-area identifiers
+ * @param Declaration [decl]
+ * @return Array<String>
+ */
+function parseGridAreaIdentifiers (decl) {
+  const parsed = parser(decl.value)
+  const identifiers = []
+  parsed.walk(({ value, type }) => {
+    if (type === 'word' && value !== 'span' && isValidCssIdentifier(value)) {
+      identifiers.push(value)
+    }
+  })
+  return identifiers
+}
+
+/**
+ * Parse all grid-template(-areas) strings and return an array
+ * @param Declaration [decl]
+ * @return Array<String>
+ */
+function parseGridTemplateStrings (decl) {
+  const result = []
+  decl.root().walkDecls(/grid-template(-areas)?$/, d => {
+    const media = getParentMedia(d.parent)
+    if (!media) {
+      const gap = getGridGap(decl)
+      const template = parseTemplate({ decl: d, gap })
+      const keys = Object.keys(template.areas)
+      if (keys.length > 0) {
+        result.push(keys.join(' '))
+      }
+    }
+  })
+  return result
+}
+
+/**
+ * Find non-unique grid-area identifiers from declaration
+ * @param Declaration [decl]
+ * @return Array<String>
+ */
+function findNonUniqueAreaIdentifiers (decl) {
+  // ignore declarations inside media
+  if (getParentMedia(decl.parent)) {
+    return false
+  }
+  const customIdentifiers = parseGridAreaIdentifiers(decl)
+  if (customIdentifiers.length > 0) {
+    // parse grid-template strings from all rules
+    const gridStrings = parseGridTemplateStrings(decl)
+
+    // find non-unique items by filtering
+    const result = customIdentifiers.filter(identifier => {
+      let found = false
+      return gridStrings.some((str, index) => {
+        if (regexp(identifier, false).test(str) && found && index > 0) {
+          return true
+        } else if (regexp(identifier, false).test(str)) {
+          found = true
+        }
+        return false
+      })
+    })
+    return result
+  }
+  return false
 }
 
 // Parse grid-template-areas
@@ -407,5 +495,6 @@ module.exports = {
   prefixTrackProp,
   prefixTrackValue,
   getGridGap,
-  warnGridGap
+  warnGridGap,
+  findNonUniqueAreaIdentifiers
 }

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -1,5 +1,6 @@
 const parser = require('postcss-value-parser')
 const regexp = require('../utils').regexp
+const list = require('postcss').list
 
 function convert (value) {
   if (value &&
@@ -201,10 +202,35 @@ function parseGridTemplateStrings (decl) {
  * @return Array<String>
  */
 function findNonUniqueAreaIdentifiers (decl) {
-  // ignore declarations inside media
-  if (getParentMedia(decl.parent)) {
-    return false
+  const parent = decl.parent
+  const media = getParentMedia(parent)
+  const root = decl.root()
+
+  if (media) {
+    // break selector into list (e.g. ['.foo', '.bar'])
+    const selectorList = list.comma(parent.selector)
+    let shouldWarn = true
+    // for every selector string
+    for (const sel of selectorList) {
+      // walk through every rule
+      root.walkRules(rule => {
+        const isEqual = parent.toString() === rule.toString()
+        // if selectors are the same && we're not on the same rule
+        if (rule.selector === sel && !isEqual) {
+          rule.walkDecls('grid-area', d => {
+            // compare declarations
+            if (d.value === decl.value) {
+              shouldWarn = false
+            }
+          })
+        }
+      })
+    }
+    if (!shouldWarn) {
+      return false
+    }
   }
+
   const customIdentifiers = parseGridAreaIdentifiers(decl)
   if (customIdentifiers.length > 0) {
     // parse grid-template strings from all rules

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -210,7 +210,13 @@ function warnDuplicateNames ({ decl, result }) {
     const duplicates = areas.filter(area => foundAreas.includes(area))
     if (duplicates.length > 0) {
       const word = duplicates.length > 1 ? 'names' : 'name'
-      decl.warn(result, `duplicate area ${ word }: ${ duplicates.join(', ') }`)
+      decl.warn(
+        result,
+        `
+        duplicate area ${ word } detected in rule: ${ rule.selector }
+        duplicate area ${ word }: ${ duplicates.join(', ') }
+        duplicate area names cause unexpected behavior in IE`
+      )
       return false
     }
     return undefined

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -212,10 +212,11 @@ function warnDuplicateNames ({ decl, result }) {
       const word = duplicates.length > 1 ? 'names' : 'name'
       decl.warn(
         result,
-        `
-        duplicate area ${ word } detected in rule: ${ rule.selector }
-        duplicate area ${ word }: ${ duplicates.join(', ') }
-        duplicate area names cause unexpected behavior in IE`
+        ['',
+          `  duplicate area ${ word } detected in rule: ${ rule.selector }`,
+          `  duplicate area ${ word }: ${ duplicates.join(', ') }`,
+          `  duplicate area names cause unexpected behavior in IE`
+        ].join('\n')
       )
       return false
     }

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -561,16 +561,26 @@ describe('hacks', () => {
 
     expect(result.css).toEqual(output)
     expect(result.warnings().map(i => i.toString())).toEqual([
-      'autoprefixer: <css input>:41:5: ' +
-        'duplicate area names: head, nav, main, foot',
-      'autoprefixer: <css input>:133:5: ' +
-        'duplicate area names: g, h',
-      'autoprefixer: <css input>:154:5: ' +
-        'duplicate area names: g, h',
-      'autoprefixer: <css input>:186:5: ' +
-        'duplicate area names: i, j',
-      'autoprefixer: <css input>:228:5: ' +
-        'duplicate area name: m'
+      `autoprefixer: <css input>:41:5: 
+        duplicate area names detected in rule: .f
+        duplicate area names: head, nav, main, foot
+        duplicate area names cause unexpected behavior in IE`,
+      `autoprefixer: <css input>:133:5: 
+        duplicate area names detected in rule: .g-conflict
+        duplicate area names: g, h
+        duplicate area names cause unexpected behavior in IE`,
+      `autoprefixer: <css input>:154:5: 
+        duplicate area names detected in rule: .g-conflict-2
+        duplicate area names: g, h
+        duplicate area names cause unexpected behavior in IE`,
+      `autoprefixer: <css input>:186:5: 
+        duplicate area names detected in rule: .k
+        duplicate area names: i, j
+        duplicate area names cause unexpected behavior in IE`,
+      `autoprefixer: <css input>:228:5: 
+        duplicate area name detected in rule: .z
+        duplicate area name: m
+        duplicate area names cause unexpected behavior in IE`
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -553,6 +553,26 @@ describe('hacks', () => {
     expect(result.warnings()).toEqual([])
   })
 
+  // TODO: add normal warnings output
+  it('shows warning if grid-area has a non-unique identifier', () => {
+    const input = read('grid-template')
+    const output = read('grid-template.out')
+    const instance = prefixer('grid-area')
+    const result = postcss([instance]).process(input)
+
+    expect(result.css).toEqual(output)
+    expect(result.warnings().map(i => i.toString())).toEqual([
+      'autoprefixer: <css input>:49:5: ' +
+        'grid-area identifier is not unique: head',
+      'autoprefixer: <css input>:53:5: ' +
+        'grid-area identifier is not unique: nav',
+      'autoprefixer: <css input>:57:5: ' +
+        'grid-area identifier is not unique: main',
+      'autoprefixer: <css input>:61:5: ' +
+        'grid-area identifier is not unique: foot'
+    ])
+  })
+
   it('ignores values for CSS3PIE props', () => {
     const css = read('pie')
     expect(postcss([compiler]).process(css).css).toEqual(css)

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -553,7 +553,6 @@ describe('hacks', () => {
     expect(result.warnings()).toEqual([])
   })
 
-  // TODO: add normal warnings output
   it('shows warning if grid-area has a non-unique identifier', () => {
     const input = read('grid-template')
     const output = read('grid-template.out')

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -568,7 +568,17 @@ describe('hacks', () => {
       'autoprefixer: <css input>:57:5: ' +
         'grid-area identifier is not unique: main',
       'autoprefixer: <css input>:61:5: ' +
-        'grid-area identifier is not unique: foot'
+        'grid-area identifier is not unique: foot',
+      'autoprefixer: <css input>:140:5: ' +
+        'grid-area identifier is not unique: h',
+      'autoprefixer: <css input>:144:5: ' +
+        'grid-area identifier is not unique: h',
+      'autoprefixer: <css input>:148:5: ' +
+        'grid-area identifier is not unique: g',
+      'autoprefixer: <css input>:156:9: ' +
+        'grid-area identifier is not unique: g',
+      'autoprefixer: <css input>:162:9: ' +
+        'grid-area identifier is not unique: g'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -561,26 +561,36 @@ describe('hacks', () => {
 
     expect(result.css).toEqual(output)
     expect(result.warnings().map(i => i.toString())).toEqual([
-      `autoprefixer: <css input>:41:5: 
-        duplicate area names detected in rule: .f
-        duplicate area names: head, nav, main, foot
-        duplicate area names cause unexpected behavior in IE`,
-      `autoprefixer: <css input>:133:5: 
-        duplicate area names detected in rule: .g-conflict
-        duplicate area names: g, h
-        duplicate area names cause unexpected behavior in IE`,
-      `autoprefixer: <css input>:154:5: 
-        duplicate area names detected in rule: .g-conflict-2
-        duplicate area names: g, h
-        duplicate area names cause unexpected behavior in IE`,
-      `autoprefixer: <css input>:186:5: 
-        duplicate area names detected in rule: .k
-        duplicate area names: i, j
-        duplicate area names cause unexpected behavior in IE`,
-      `autoprefixer: <css input>:228:5: 
-        duplicate area name detected in rule: .z
-        duplicate area name: m
-        duplicate area names cause unexpected behavior in IE`
+      [
+        `autoprefixer: <css input>:41:5: `,
+        `  duplicate area names detected in rule: .f`,
+        `  duplicate area names: head, nav, main, foot`,
+        `  duplicate area names cause unexpected behavior in IE`
+      ].join('\n'),
+      [
+        `autoprefixer: <css input>:133:5: `,
+        `  duplicate area names detected in rule: .g-conflict`,
+        `  duplicate area names: g, h`,
+        `  duplicate area names cause unexpected behavior in IE`
+      ].join('\n'),
+      [
+        `autoprefixer: <css input>:154:5: `,
+        `  duplicate area names detected in rule: .g-conflict-2`,
+        `  duplicate area names: g, h`,
+        `  duplicate area names cause unexpected behavior in IE`
+      ].join('\n'),
+      [
+        `autoprefixer: <css input>:186:5: `,
+        `  duplicate area names detected in rule: .k`,
+        `  duplicate area names: i, j`,
+        `  duplicate area names cause unexpected behavior in IE`
+      ].join('\n'),
+      [
+        `autoprefixer: <css input>:228:5: `,
+        `  duplicate area name detected in rule: .z`,
+        `  duplicate area name: m`,
+        `  duplicate area names cause unexpected behavior in IE`
+      ].join('\n')
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -553,7 +553,7 @@ describe('hacks', () => {
     expect(result.warnings()).toEqual([])
   })
 
-  it('shows warning if grid-area has a non-unique identifier', () => {
+  it('shows warning if grid-template has a duplicate area name', () => {
     const input = read('grid-template')
     const output = read('grid-template.out')
     const instance = prefixer('grid-area')
@@ -561,24 +561,16 @@ describe('hacks', () => {
 
     expect(result.css).toEqual(output)
     expect(result.warnings().map(i => i.toString())).toEqual([
-      'autoprefixer: <css input>:49:5: ' +
-        'grid-area identifier is not unique: head',
-      'autoprefixer: <css input>:53:5: ' +
-        'grid-area identifier is not unique: nav',
-      'autoprefixer: <css input>:57:5: ' +
-        'grid-area identifier is not unique: main',
-      'autoprefixer: <css input>:61:5: ' +
-        'grid-area identifier is not unique: foot',
-      'autoprefixer: <css input>:140:5: ' +
-        'grid-area identifier is not unique: h',
-      'autoprefixer: <css input>:144:5: ' +
-        'grid-area identifier is not unique: h',
-      'autoprefixer: <css input>:148:5: ' +
-        'grid-area identifier is not unique: g',
-      'autoprefixer: <css input>:156:9: ' +
-        'grid-area identifier is not unique: g',
-      'autoprefixer: <css input>:162:9: ' +
-        'grid-area identifier is not unique: g'
+      'autoprefixer: <css input>:41:5: ' +
+        'duplicate area names: head, nav, main, foot',
+      'autoprefixer: <css input>:133:5: ' +
+        'duplicate area names: g, h',
+      'autoprefixer: <css input>:154:5: ' +
+        'duplicate area names: g, h',
+      'autoprefixer: <css input>:186:5: ' +
+        'duplicate area names: i, j',
+      'autoprefixer: <css input>:228:5: ' +
+        'duplicate area name: m'
     ])
   })
 

--- a/test/cases/grid-template.css
+++ b/test/cases/grid-template.css
@@ -97,26 +97,6 @@
     }
 }
 
-.g {
-    display: grid;
-    grid-gap: 10px;
-    grid-template:
-        "g   g" 100px
-        "g   g" 100px
-        "h   h" 100px /
-        1fr  1fr;
-}
-
-.g-conflict {
-    display: grid;
-    grid-gap: 10px;
-    grid-template:
-        "g   g" 100px
-        "g   g" 100px
-        "h   h" 100px /
-        1fr  1fr;
-}
-
 .cell-A {
     grid-area: a;
 }
@@ -136,29 +116,145 @@
     grid-area: f;
 }
 
-.h {
-    grid-area: h;
+.g {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
 }
 
-.i {
-    grid-area: h;
+/* Should trigger a warning */
+.g-conflict {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
 }
 
-.j {
+@media (min-width: 600px) {
+  /* This should *not* trigger a warning */
+  .g {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   h" 100px /
+        1fr  1fr;
+  }
+
+  /* This *should* trigger a warning */
+  .g-conflict-2 {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   h" 100px /
+        1fr  1fr;
+  }
+}
+
+/* comma list tests */
+/* None of these should throw any warnings (unless specified) */
+.i, .j {
+  display: grid;
+  grid-gap: 10px;
+  grid-template:
+      "i    j" 100px /
+      1fr  1fr;
+}
+
+@media (max-width: 600px) {
+  .i {
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+  .j {
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+
+  /* This one should throw a warning */
+  .k {
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+}
+
+@media (min-width: 900px) {
+  .i, .j {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+}
+
+/* media query test */
+@media (min-width: 601px) {
+  .l {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "l   m" 100px /
+        1fr  1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .l {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "l   m" 100px /
+        1fr  1fr;
+  }
+
+  /* this should display a warning */
+  .z {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "m   z" 100px /
+        1fr  1fr;
+  }
+}
+
+.k-1 {
     grid-area: g;
 }
 
-@media(min-width: 400px) {
-    .h {
-        grid-area: h;
-    }
-    .i {
-        grid-area: g;
-    }
-    .j {
-        grid-area: g;
-    }
-    .g > .j {
-        grid-area: g;
-    }
+.k-2 {
+    grid-area: h;
+}
+
+.k-3 {
+    grid-area: i;
+}
+
+.k-4 {
+    grid-area: j;
+}
+
+.k-6 {
+    grid-area: l;
+}
+
+.k-6 {
+    grid-area: m;
+}
+
+.k-7 {
+    grid-area: z;
 }

--- a/test/cases/grid-template.css
+++ b/test/cases/grid-template.css
@@ -97,6 +97,26 @@
     }
 }
 
+.g {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
+}
+
+.g-conflict {
+    display: grid;
+    grid-gap: 10px;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
+}
+
 .cell-A {
     grid-area: a;
 }
@@ -114,4 +134,31 @@
 }
 .cell-F {
     grid-area: f;
+}
+
+.h {
+    grid-area: h;
+}
+
+.i {
+    grid-area: h;
+}
+
+.j {
+    grid-area: g;
+}
+
+@media(min-width: 400px) {
+    .h {
+        grid-area: h;
+    }
+    .i {
+        grid-area: g;
+    }
+    .j {
+        grid-area: g;
+    }
+    .g > .j {
+        grid-area: g;
+    }
 }

--- a/test/cases/grid-template.out.css
+++ b/test/cases/grid-template.out.css
@@ -155,32 +155,6 @@
     }
 }
 
-.g {
-    display: -ms-grid;
-    display: grid;
-    grid-gap: 10px;
-    -ms-grid-rows: 100px 10px 100px 10px 100px;
-    -ms-grid-columns: 1fr 10px 1fr;
-    grid-template:
-        "g   g" 100px
-        "g   g" 100px
-        "h   h" 100px /
-        1fr  1fr;
-}
-
-.g-conflict {
-    display: -ms-grid;
-    display: grid;
-    grid-gap: 10px;
-    -ms-grid-rows: 100px 10px 100px 10px 100px;
-    -ms-grid-columns: 1fr 10px 1fr;
-    grid-template:
-        "g   g" 100px
-        "g   g" 100px
-        "h   h" 100px /
-        1fr  1fr;
-}
-
 .cell-A {
     -ms-grid-row: 1;
     -ms-grid-column: 1;
@@ -238,21 +212,155 @@
     }
 }
 
-.h {
-    -ms-grid-row: 5;
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 3;
-    grid-area: h;
+.g {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px 10px 100px 10px 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
 }
 
-.i {
-    -ms-grid-row: 5;
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 3;
-    grid-area: h;
+/* Should trigger a warning */
+.g-conflict {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px 10px 100px 10px 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
 }
 
-.j {
+@media (min-width: 600px) {
+  /* This should *not* trigger a warning */
+  .g {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   h" 100px /
+        1fr  1fr;
+  }
+
+  /* This *should* trigger a warning */
+  .g-conflict-2 {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   h" 100px /
+        1fr  1fr;
+  }
+}
+
+/* comma list tests */
+/* None of these should throw any warnings (unless specified) */
+.i, .j {
+  display: -ms-grid;
+  display: grid;
+  grid-gap: 10px;
+  -ms-grid-rows: 100px;
+  -ms-grid-columns: 1fr 10px 1fr;
+  grid-template:
+      "i    j" 100px /
+      1fr  1fr;
+}
+
+@media (max-width: 600px) {
+  .i {
+    -ms-grid-rows: 100px 100px;
+    -ms-grid-columns: 1fr;
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+  .j {
+    -ms-grid-rows: 100px 100px;
+    -ms-grid-columns: 1fr;
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+
+  /* This one should throw a warning */
+  .k {
+    -ms-grid-rows: 100px 100px;
+    -ms-grid-columns: 1fr;
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+}
+
+@media (min-width: 900px) {
+  .i, .j {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px 10px 100px;
+    -ms-grid-columns: 1fr;
+    grid-template:
+      "i" 100px
+      "j" 100px /
+      1fr;
+  }
+}
+
+/* media query test */
+@media (min-width: 601px) {
+  .l {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "l   m" 100px /
+        1fr  1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .l {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "l   m" 100px /
+        1fr  1fr;
+  }
+
+  /* this should display a warning */
+  .z {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "m   z" 100px /
+        1fr  1fr;
+  }
+}
+
+.k-1 {
     -ms-grid-row: 1;
     -ms-grid-row-span: 3;
     -ms-grid-column: 1;
@@ -260,32 +368,110 @@
     grid-area: g;
 }
 
-@media(min-width: 400px) {
-    .h {
-        -ms-grid-row: 5;
-        -ms-grid-column: 1;
-        -ms-grid-column-span: 3;
-        grid-area: h;
-    }
-    .i {
+.k-2 {
+    -ms-grid-row: 5;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 3;
+    grid-area: h;
+}
+
+@media (min-width: 600px) {
+  .k-1 {
         -ms-grid-row: 1;
-        -ms-grid-row-span: 3;
         -ms-grid-column: 1;
-        -ms-grid-column-span: 3;
-        grid-area: g;
-    }
-    .j {
+  }
+  .k-2 {
         -ms-grid-row: 1;
-        -ms-grid-row-span: 3;
-        -ms-grid-column: 1;
-        -ms-grid-column-span: 3;
-        grid-area: g;
-    }
-    .g > .j {
+        -ms-grid-column: 3;
+  }
+}
+
+@media (min-width: 600px) {
+  .k-1 {
         -ms-grid-row: 1;
-        -ms-grid-row-span: 3;
         -ms-grid-column: 1;
-        -ms-grid-column-span: 3;
-        grid-area: g;
-    }
+  }
+  .k-2 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 3;
+  }
+}
+
+.k-3 {
+    -ms-grid-row: 1;
+    -ms-grid-column: 1;
+    grid-area: i;
+}
+
+.k-4 {
+    -ms-grid-row: 1;
+    -ms-grid-column: 3;
+    grid-area: j;
+}
+
+@media (min-width: 900px) {
+  .k-3 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 1;
+  }
+  .k-4 {
+        -ms-grid-row: 3;
+        -ms-grid-column: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .k-3 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 1;
+  }
+  .k-4 {
+        -ms-grid-row: 2;
+        -ms-grid-column: 1;
+  }
+}
+
+.k-6 {
+    grid-area: l;
+}
+
+.k-6 {
+    grid-area: m;
+}
+
+@media (max-width: 600px) {
+  .k-6 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 1;
+  }
+  .k-6 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 3;
+  }
+}
+
+@media (min-width: 601px) {
+  .k-6 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 1;
+  }
+  .k-6 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 3;
+  }
+}
+
+.k-7 {
+    grid-area: z;
+}
+
+@media (max-width: 600px) {
+  .k-6 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 1;
+  }
+  .k-7 {
+        -ms-grid-row: 1;
+        -ms-grid-column: 3;
+  }
 }

--- a/test/cases/grid-template.out.css
+++ b/test/cases/grid-template.out.css
@@ -155,6 +155,32 @@
     }
 }
 
+.g {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px 10px 100px 10px 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
+}
+
+.g-conflict {
+    display: -ms-grid;
+    display: grid;
+    grid-gap: 10px;
+    -ms-grid-rows: 100px 10px 100px 10px 100px;
+    -ms-grid-columns: 1fr 10px 1fr;
+    grid-template:
+        "g   g" 100px
+        "g   g" 100px
+        "h   h" 100px /
+        1fr  1fr;
+}
+
 .cell-A {
     -ms-grid-row: 1;
     -ms-grid-column: 1;
@@ -209,5 +235,57 @@
     .cell-F {
         -ms-grid-row: 3;
         -ms-grid-column: 5;
+    }
+}
+
+.h {
+    -ms-grid-row: 5;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 3;
+    grid-area: h;
+}
+
+.i {
+    -ms-grid-row: 5;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 3;
+    grid-area: h;
+}
+
+.j {
+    -ms-grid-row: 1;
+    -ms-grid-row-span: 3;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 3;
+    grid-area: g;
+}
+
+@media(min-width: 400px) {
+    .h {
+        -ms-grid-row: 5;
+        -ms-grid-column: 1;
+        -ms-grid-column-span: 3;
+        grid-area: h;
+    }
+    .i {
+        -ms-grid-row: 1;
+        -ms-grid-row-span: 3;
+        -ms-grid-column: 1;
+        -ms-grid-column-span: 3;
+        grid-area: g;
+    }
+    .j {
+        -ms-grid-row: 1;
+        -ms-grid-row-span: 3;
+        -ms-grid-column: 1;
+        -ms-grid-column-span: 3;
+        grid-area: g;
+    }
+    .g > .j {
+        -ms-grid-row: 1;
+        -ms-grid-row-span: 3;
+        -ms-grid-column: 1;
+        -ms-grid-column-span: 3;
+        grid-area: g;
     }
 }


### PR DESCRIPTION
This is my first PR which adds warning when grid-area has a non-unique identifier (conflict of names). #1038

Not sure if code is clean enough, but I had a lot of fun working on this issue. Thanks! :)

Some questions:
* In my code I refer to area names in grid-area as "identifiers" ([see this](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)). Is it alright?
* How should we handle grid-area inside media? I've omitted checking warnings inside media for now