### PR TITLE
[grid-template] fix adding grid span for IE (fixes #1084)

### DIFF
--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -394,15 +394,11 @@ function getParentMedia (parent) {
 function shouldAddSpan (decl, area, areaName) {
   const root = decl.root()
   const rule = decl.parent
-  const media = getParentMedia(rule)
-  const ruleIndex = root.index(media) + media.index(rule)
   const overrideValues = [false, false]
 
   root.walkRules(rule.selector, node => {
-    const comparedRuleIndex = root.index(node) + media.index(node)
-
     // abort if we are on the same rule
-    if (ruleIndex === comparedRuleIndex) {
+    if (rule.toString() === node.toString()) {
       return false
     }
 

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -1,5 +1,5 @@
-const parser = require('postcss-value-parser')
-const list = require('postcss').list
+let parser = require('postcss-value-parser')
+let list = require('postcss').list
 
 function convert (value) {
   if (value &&
@@ -21,15 +21,15 @@ function convert (value) {
 }
 
 function translate (values, startIndex, endIndex) {
-  const startValue = values[startIndex]
-  const endValue = values[endIndex]
+  let startValue = values[startIndex]
+  let endValue = values[endIndex]
 
   if (!startValue) {
     return [false, false]
   }
 
-  const [start, spanStart] = convert(startValue)
-  const [end, spanEnd] = convert(endValue)
+  let [start, spanStart] = convert(startValue)
+  let [end, spanEnd] = convert(endValue)
 
   if (start && !endValue) {
     return [start, false]
@@ -51,13 +51,13 @@ function translate (values, startIndex, endIndex) {
 }
 
 function parse (decl) {
-  const node = parser(decl.value)
+  let node = parser(decl.value)
 
-  const values = []
+  let values = []
   let current = 0
   values[current] = []
 
-  for (const i of node.nodes) {
+  for (let i of node.nodes) {
     if (i.type === 'div') {
       current += 1
       values[current] = []
@@ -85,7 +85,7 @@ function prefixTrackProp ({ prop, prefix }) {
 }
 
 function transformRepeat ({ nodes }, { gap }) {
-  const {
+  let {
     count,
     size
   } = nodes.reduce((result, node) => {
@@ -102,7 +102,7 @@ function transformRepeat ({ nodes }, { gap }) {
   })
 
   if (gap) {
-    const val = []
+    let val = []
     for (let i = 1; i <= count; i++) {
       if (gap && i > 1) {
         val.push(gap)
@@ -116,7 +116,7 @@ function transformRepeat ({ nodes }, { gap }) {
 }
 
 function prefixTrackValue ({ value, gap }) {
-  const result = parser(value)
+  let result = parser(value)
     .nodes
     .reduce((nodes, node) => {
       if (node.type === 'function' && node.value === 'repeat') {
@@ -146,7 +146,7 @@ function prefixTrackValue ({ value, gap }) {
  * @return Array<String>
  */
 function parseGridTemplateStrings (decl) {
-  const template = parseTemplate({ decl, gap: getGridGap(decl) })
+  let template = parseTemplate({ decl, gap: getGridGap(decl) })
   return Object.keys(template.areas)
 }
 
@@ -158,10 +158,10 @@ function parseGridTemplateStrings (decl) {
  * @return {void}
  */
 function warnDuplicateNames ({ decl, result }) {
-  const rule = decl.parent
-  const inMediaRule = !!getParentMedia(rule)
-  const areas = parseGridTemplateStrings(decl)
-  const root = decl.root()
+  let rule = decl.parent
+  let inMediaRule = !!getParentMedia(rule)
+  let areas = parseGridTemplateStrings(decl)
+  let root = decl.root()
 
   // stop if no areas found
   if (areas.length === 0) {
@@ -169,12 +169,12 @@ function warnDuplicateNames ({ decl, result }) {
   }
 
   root.walkDecls(/grid-template(-areas)?$/g, d => {
-    const nodeRule = d.parent
-    const nodeRuleMedia = getParentMedia(nodeRule)
-    const isEqual = rule.toString() === nodeRule.toString()
-    const foundAreas = parseGridTemplateStrings(d)
-    const maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
-    const isLookingDown = root.index(rule) < maxIndex
+    let nodeRule = d.parent
+    let nodeRuleMedia = getParentMedia(nodeRule)
+    let isEqual = rule.toString() === nodeRule.toString()
+    let foundAreas = parseGridTemplateStrings(d)
+    let maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
+    let isLookingDown = root.index(rule) < maxIndex
 
     // skip node if no grid areas is found
     if (foundAreas.length === 0) {
@@ -194,8 +194,8 @@ function warnDuplicateNames ({ decl, result }) {
 
     // if we're inside media rule, we need to compare selectors
     if (inMediaRule) {
-      const selectors = list.comma(nodeRule.selector)
-      const selectorIsFound = selectors.some(sel => {
+      let selectors = list.comma(nodeRule.selector)
+      let selectorIsFound = selectors.some(sel => {
         if (sel === rule.selector) {
           // compare selectors as a comma list
           return true
@@ -212,9 +212,9 @@ function warnDuplicateNames ({ decl, result }) {
       }
     }
 
-    const duplicates = areas.filter(area => foundAreas.includes(area))
+    let duplicates = areas.filter(area => foundAreas.includes(area))
     if (duplicates.length > 0) {
-      const word = duplicates.length > 1 ? 'names' : 'name'
+      let word = duplicates.length > 1 ? 'names' : 'name'
       decl.warn(
         result,
         ['',
@@ -232,7 +232,7 @@ function warnDuplicateNames ({ decl, result }) {
 
 // Parse grid-template-areas
 
-const DOTS = /^\.+$/
+let DOTS = /^\.+$/
 
 function track (start, end) {
   return { start, end, span: end - start }
@@ -262,7 +262,7 @@ function parseGridAreas ({
           row: track(rowIndex + 1, rowIndex + 2)
         }
       } else {
-        const { column, row } = areas[area]
+        let { column, row } = areas[area]
 
         column.start = Math.min(column.start, columnIndex + 1)
         column.end = Math.max(column.end, columnIndex + 2)
@@ -295,10 +295,10 @@ function parseTemplate ({
   decl,
   gap
 }) {
-  const gridTemplate = parser(decl.value)
+  let gridTemplate = parser(decl.value)
     .nodes
     .reduce((result, node) => {
-      const { type, value } = node
+      let { type, value } = node
 
       if (testTrack(node) || type === 'space') return result
 
@@ -427,20 +427,20 @@ function shouldAddSpan (decl, area, areaName) {
 function insertAreas (areas, decl, result) {
   let missed = Object.keys(areas)
 
-  const parentMedia = getParentMedia(decl.parent)
-  const rules = []
-  const areasLength = Object.keys(areas).length
+  let parentMedia = getParentMedia(decl.parent)
+  let rules = []
+  let areasLength = Object.keys(areas).length
   let areasCount = 0
 
   decl.root().walkDecls('grid-area', gridArea => {
-    const value = gridArea.value
-    const area = areas[value]
+    let value = gridArea.value
+    let area = areas[value]
 
     missed = missed.filter(e => e !== value)
 
     if (area && parentMedia) {
       // create new rule
-      const rule = decl.parent.clone({
+      let rule = decl.parent.clone({
         selector: gridArea.parent.selector
       })
       rule.removeAll()
@@ -459,7 +459,7 @@ function insertAreas (areas, decl, result) {
       rules.push(rule)
       areasCount++
       if (areasCount === areasLength) {
-        const next = gridArea.parent.next()
+        let next = gridArea.parent.next()
 
         if (
           next &&
@@ -471,8 +471,8 @@ function insertAreas (areas, decl, result) {
                     /^-ms-/.test(next.first.first.prop)
         ) return undefined
 
-        const areaParentMedia = getParentMedia(gridArea.parent)
-        const areaMedia = parentMedia.clone().removeAll().append(rules)
+        let areaParentMedia = getParentMedia(gridArea.parent)
+        let areaMedia = parentMedia.clone().removeAll().append(rules)
         if (areaParentMedia) {
           areaParentMedia.after(areaMedia)
         } else {
@@ -504,13 +504,13 @@ function insertAreas (areas, decl, result) {
 // Gap utils
 
 function getGridGap (decl) {
-  const gap = {}
+  let gap = {}
 
   // try to find gap
-  const testGap = /^(grid-)?((row|column)-)?gap$/
+  let testGap = /^(grid-)?((row|column)-)?gap$/
   decl.parent.walkDecls(testGap, ({ prop, value }) => {
     if (/^(grid-)?gap$/.test(prop)) {
-      const [row = {},, column = {}] = parser(value).nodes
+      let [row = {},, column = {}] = parser(value).nodes
 
       gap.row = row.value
       gap.column = column.value || row.value
@@ -528,7 +528,7 @@ function warnGridGap ({
   decl,
   result
 }) {
-  const hasBothGaps = gap.row && gap.column
+  let hasBothGaps = gap.row && gap.column
   if (!hasColumns && (hasBothGaps || (gap.column && !gap.row))) {
     delete gap.column
     decl.warn(

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -1,5 +1,5 @@
-let parser = require('postcss-value-parser')
-let list = require('postcss').list
+const parser = require('postcss-value-parser')
+const list = require('postcss').list
 
 function convert (value) {
   if (value &&
@@ -21,15 +21,15 @@ function convert (value) {
 }
 
 function translate (values, startIndex, endIndex) {
-  let startValue = values[startIndex]
-  let endValue = values[endIndex]
+  const startValue = values[startIndex]
+  const endValue = values[endIndex]
 
   if (!startValue) {
     return [false, false]
   }
 
-  let [start, spanStart] = convert(startValue)
-  let [end, spanEnd] = convert(endValue)
+  const [start, spanStart] = convert(startValue)
+  const [end, spanEnd] = convert(endValue)
 
   if (start && !endValue) {
     return [start, false]
@@ -51,13 +51,13 @@ function translate (values, startIndex, endIndex) {
 }
 
 function parse (decl) {
-  let node = parser(decl.value)
+  const node = parser(decl.value)
 
-  let values = []
+  const values = []
   let current = 0
   values[current] = []
 
-  for (let i of node.nodes) {
+  for (const i of node.nodes) {
     if (i.type === 'div') {
       current += 1
       values[current] = []
@@ -85,7 +85,7 @@ function prefixTrackProp ({ prop, prefix }) {
 }
 
 function transformRepeat ({ nodes }, { gap }) {
-  let {
+  const {
     count,
     size
   } = nodes.reduce((result, node) => {
@@ -102,7 +102,7 @@ function transformRepeat ({ nodes }, { gap }) {
   })
 
   if (gap) {
-    let val = []
+    const val = []
     for (let i = 1; i <= count; i++) {
       if (gap && i > 1) {
         val.push(gap)
@@ -116,7 +116,7 @@ function transformRepeat ({ nodes }, { gap }) {
 }
 
 function prefixTrackValue ({ value, gap }) {
-  let result = parser(value)
+  const result = parser(value)
     .nodes
     .reduce((nodes, node) => {
       if (node.type === 'function' && node.value === 'repeat') {
@@ -146,7 +146,7 @@ function prefixTrackValue ({ value, gap }) {
  * @return Array<String>
  */
 function parseGridTemplateStrings (decl) {
-  let template = parseTemplate({ decl, gap: getGridGap(decl) })
+  const template = parseTemplate({ decl, gap: getGridGap(decl) })
   return Object.keys(template.areas)
 }
 
@@ -158,10 +158,10 @@ function parseGridTemplateStrings (decl) {
  * @return {void}
  */
 function warnDuplicateNames ({ decl, result }) {
-  let rule = decl.parent
-  let inMediaRule = !!getParentMedia(rule)
-  let areas = parseGridTemplateStrings(decl)
-  let root = decl.root()
+  const rule = decl.parent
+  const inMediaRule = !!getParentMedia(rule)
+  const areas = parseGridTemplateStrings(decl)
+  const root = decl.root()
 
   // stop if no areas found
   if (areas.length === 0) {
@@ -169,12 +169,12 @@ function warnDuplicateNames ({ decl, result }) {
   }
 
   root.walkDecls(/grid-template(-areas)?$/g, d => {
-    let nodeRule = d.parent
-    let nodeRuleMedia = getParentMedia(nodeRule)
-    let isEqual = rule.toString() === nodeRule.toString()
-    let foundAreas = parseGridTemplateStrings(d)
-    let maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
-    let isLookingDown = root.index(rule) < maxIndex
+    const nodeRule = d.parent
+    const nodeRuleMedia = getParentMedia(nodeRule)
+    const isEqual = rule.toString() === nodeRule.toString()
+    const foundAreas = parseGridTemplateStrings(d)
+    const maxIndex = Math.max(root.index(nodeRule), root.index(nodeRuleMedia))
+    const isLookingDown = root.index(rule) < maxIndex
 
     // skip node if no grid areas is found
     if (foundAreas.length === 0) {
@@ -194,8 +194,8 @@ function warnDuplicateNames ({ decl, result }) {
 
     // if we're inside media rule, we need to compare selectors
     if (inMediaRule) {
-      let selectors = list.comma(nodeRule.selector)
-      let selectorIsFound = selectors.some(sel => {
+      const selectors = list.comma(nodeRule.selector)
+      const selectorIsFound = selectors.some(sel => {
         if (sel === rule.selector) {
           // compare selectors as a comma list
           return true
@@ -212,9 +212,9 @@ function warnDuplicateNames ({ decl, result }) {
       }
     }
 
-    let duplicates = areas.filter(area => foundAreas.includes(area))
+    const duplicates = areas.filter(area => foundAreas.includes(area))
     if (duplicates.length > 0) {
-      let word = duplicates.length > 1 ? 'names' : 'name'
+      const word = duplicates.length > 1 ? 'names' : 'name'
       decl.warn(
         result,
         ['',
@@ -232,7 +232,7 @@ function warnDuplicateNames ({ decl, result }) {
 
 // Parse grid-template-areas
 
-let DOTS = /^\.+$/
+const DOTS = /^\.+$/
 
 function track (start, end) {
   return { start, end, span: end - start }
@@ -262,7 +262,7 @@ function parseGridAreas ({
           row: track(rowIndex + 1, rowIndex + 2)
         }
       } else {
-        let { column, row } = areas[area]
+        const { column, row } = areas[area]
 
         column.start = Math.min(column.start, columnIndex + 1)
         column.end = Math.max(column.end, columnIndex + 2)
@@ -295,10 +295,10 @@ function parseTemplate ({
   decl,
   gap
 }) {
-  let gridTemplate = parser(decl.value)
+  const gridTemplate = parser(decl.value)
     .nodes
     .reduce((result, node) => {
-      let { type, value } = node
+      const { type, value } = node
 
       if (testTrack(node) || type === 'space') return result
 
@@ -345,13 +345,20 @@ function parseTemplate ({
 
 // Insert parsed grid areas
 
-function getMSDecls (area) {
+/**
+ * Get an array of -ms- prefixed props and values
+ * @param  {Object} [area] area object with columm and row data
+ * @param  {Boolean} [addRowSpan] should we add grid-column-row value?
+ * @param  {Boolean} [addColumnSpan] should we add grid-column-span value?
+ * @return {Array<Object>}
+ */
+function getMSDecls (area, addRowSpan = false, addColumnSpan = false) {
   return [].concat(
     {
       prop: '-ms-grid-row',
       value: String(area.row.start)
     },
-    area.row.span > 1 ? {
+    (area.row.span > 1 || addRowSpan) ? {
       prop: '-ms-grid-row-span',
       value: String(area.row.span)
     } : [],
@@ -359,7 +366,7 @@ function getMSDecls (area) {
       prop: '-ms-grid-column',
       value: String(area.column.start)
     },
-    area.column.span > 1 ? {
+    (area.column.span > 1 || addColumnSpan) ? {
       prop: '-ms-grid-column-span',
       value: String(area.column.span)
     } : []
@@ -375,29 +382,72 @@ function getParentMedia (parent) {
   return getParentMedia(parent.parent)
 }
 
+/**
+ * Check grid-template(-areas) rules with the same selector for
+ * -ms-grid-(row|column)-span values. If initial and compared values are
+ * different - return an array of boolean values which need to be updated
+ * @param  {Declaration} decl
+ * @param  {Object} area area object with column and row data
+ * @param  {String} areaName area name (e.g. "head")
+ * @return {Array<Boolean, Boolean>}
+ */
+function shouldAddSpan (decl, area, areaName) {
+  const root = decl.root()
+  const rule = decl.parent
+  const media = getParentMedia(rule)
+  const ruleIndex = root.index(media) + media.index(rule)
+  const overrideValues = [false, false]
+
+  root.walkRules(rule.selector, node => {
+    const comparedRuleIndex = root.index(node) + media.index(node)
+
+    // abort if we are on the same rule
+    if (ruleIndex === comparedRuleIndex) {
+      return false
+    }
+
+    node.walkDecls('grid-template', d => {
+      const template = parseTemplate({ decl: d, gap: getGridGap(d) })
+      const comparedArea = template.areas[areaName]
+      if (area.row.span !== comparedArea.row.span) {
+        overrideValues[0] = true
+      } else if (area.column.span !== comparedArea.column.span) {
+        overrideValues[1] = true
+      }
+
+      return undefined
+    })
+
+    return undefined
+  })
+
+  return overrideValues
+}
+
 function insertAreas (areas, decl, result) {
   let missed = Object.keys(areas)
 
-  let parentMedia = getParentMedia(decl.parent)
-  let rules = []
-  let areasLength = Object.keys(areas).length
+  const parentMedia = getParentMedia(decl.parent)
+  const rules = []
+  const areasLength = Object.keys(areas).length
   let areasCount = 0
 
   decl.root().walkDecls('grid-area', gridArea => {
-    let value = gridArea.value
-    let area = areas[value]
+    const value = gridArea.value
+    const area = areas[value]
 
     missed = missed.filter(e => e !== value)
 
     if (area && parentMedia) {
       // create new rule
-      let rule = decl.parent.clone({
+      const rule = decl.parent.clone({
         selector: gridArea.parent.selector
       })
       rule.removeAll()
 
       // insert prefixed decls in new rule
-      getMSDecls(area)
+      const [addRowSpan, addColumnSpan] = shouldAddSpan(decl, area, value)
+      getMSDecls(area, addRowSpan, addColumnSpan)
         .forEach(i => rule.append(
           Object.assign(i, {
             raws: {
@@ -409,7 +459,7 @@ function insertAreas (areas, decl, result) {
       rules.push(rule)
       areasCount++
       if (areasCount === areasLength) {
-        let next = gridArea.parent.next()
+        const next = gridArea.parent.next()
 
         if (
           next &&
@@ -421,8 +471,8 @@ function insertAreas (areas, decl, result) {
                     /^-ms-/.test(next.first.first.prop)
         ) return undefined
 
-        let areaParentMedia = getParentMedia(gridArea.parent)
-        let areaMedia = parentMedia.clone().removeAll().append(rules)
+        const areaParentMedia = getParentMedia(gridArea.parent)
+        const areaMedia = parentMedia.clone().removeAll().append(rules)
         if (areaParentMedia) {
           areaParentMedia.after(areaMedia)
         } else {
@@ -454,13 +504,13 @@ function insertAreas (areas, decl, result) {
 // Gap utils
 
 function getGridGap (decl) {
-  let gap = {}
+  const gap = {}
 
   // try to find gap
-  let testGap = /^(grid-)?((row|column)-)?gap$/
+  const testGap = /^(grid-)?((row|column)-)?gap$/
   decl.parent.walkDecls(testGap, ({ prop, value }) => {
     if (/^(grid-)?gap$/.test(prop)) {
-      let [row = {},, column = {}] = parser(value).nodes
+      const [row = {},, column = {}] = parser(value).nodes
 
       gap.row = row.value
       gap.column = column.value || row.value
@@ -478,7 +528,7 @@ function warnGridGap ({
   decl,
   result
 }) {
-  let hasBothGaps = gap.row && gap.column
+  const hasBothGaps = gap.row && gap.column
   if (!hasColumns && (hasBothGaps || (gap.column && !gap.row))) {
     delete gap.column
     decl.warn(

--- a/test/cases/grid-template.out.css
+++ b/test/cases/grid-template.out.css
@@ -87,9 +87,11 @@
     .head {
         -ms-grid-row: 1;
         -ms-grid-column: 1;
+        -ms-grid-column-span: 1;
     }
     .nav {
         -ms-grid-row: 2;
+        -ms-grid-row-span: 1;
         -ms-grid-column: 1;
     }
     .main {
@@ -389,11 +391,13 @@
 @media (min-width: 600px) {
   .k-1 {
         -ms-grid-row: 1;
+        -ms-grid-row-span: 1;
         -ms-grid-column: 1;
   }
   .k-2 {
         -ms-grid-row: 1;
         -ms-grid-column: 3;
+        -ms-grid-column-span: 1;
   }
 }
 


### PR DESCRIPTION
This PR fixes #1084.

@Dan503 Can you please review grid-template.out.css in you spare time? I think now it should add -ms-grid-(row|column)-span just fine 👍 