### PR TITLE
Adding a basic experimentation playground to the repo

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('standalone', ['build:lib'], done => {
 })
 
 gulp.task('compile-playground', () => {
-  let autoprefixer = require('./build')
+  let autoprefixer = require('./build') // @codingStandardsIgnoreLine
   return gulp.src('./playground/playground.input.css')
     .pipe(rename('playground.output.css'))
     .pipe(postcss([autoprefixer({ grid: true })]))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,8 @@
 let gulp = require('gulp')
 let path = require('path')
 let fs = require('fs-extra')
+let postcss = require('gulp-postcss')
+let rename = require('gulp-rename')
 
 gulp.task('clean', done => {
   fs.remove(path.join(__dirname, 'autoprefixer.js'), () => {
@@ -89,6 +91,27 @@ gulp.task('standalone', ['build:lib'], done => {
       }
       done()
     })
+})
+
+gulp.task('compile-playground', () => {
+  let autoprefixer = require('./build')
+  return gulp.src('./playground/playground.input.css')
+    .pipe(rename('playground.output.css'))
+    .pipe(postcss([autoprefixer({ grid: true })]))
+    .pipe(gulp.dest('./playground'))
+})
+
+gulp.task('initialise-playground', ['build'], () => {
+  return gulp.start('compile-playground')
+})
+
+gulp.task('watch-playground', () => {
+  return gulp.watch('./playground/playground.input.css', ['compile-playground'])
+})
+
+// Experiment with the current implementation of the code
+gulp.task('play', ['initialise-playground'], () => {
+  gulp.start('watch-playground')
 })
 
 gulp.task('default', ['build'])

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^8.0.0",
     "gulp-json-editor": "^2.4.2",
+    "gulp-postcss": "^8.0.0",
+    "gulp-rename": "^1.4.0",
     "gulp-replace": "^1.0.0",
     "jest": "^23.5.0",
     "lint-staged": "^7.2.2",

--- a/playground/playground.input.css
+++ b/playground/playground.input.css
@@ -1,0 +1,11 @@
+
+/*
+  This file is purely just for experimentation.
+  1. Run the command "gulp play"
+  2. Write some CSS in playground.input.css and save the file
+  3. View the output CSS in playground.output.css
+*/
+
+.grid {
+  display: grid;
+}

--- a/playground/playground.output.css
+++ b/playground/playground.output.css
@@ -1,0 +1,11 @@
+
+/*
+  This file is purely just for experimentation.
+  1. Run the command "gulp play"
+  2. Write some CSS in playground.input.css and save the file
+  3. View the output CSS in playground.output.css
+*/
+
+.grid {
+  display: grid;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,6 +1927,15 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
+
 cosmiconfig@^5.0.2, cosmiconfig@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
@@ -2797,7 +2806,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0:
+fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -3304,6 +3313,20 @@ gulp-json-editor@^2.4.2:
     plugin-error "^1.0.1"
     through2 "^2.0.3"
 
+gulp-postcss@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-postcss/-/gulp-postcss-8.0.0.tgz#8d3772cd4d27bca55ec8cb4c8e576e3bde4dc550"
+  dependencies:
+    fancy-log "^1.3.2"
+    plugin-error "^1.0.1"
+    postcss "^7.0.2"
+    postcss-load-config "^2.0.0"
+    vinyl-sourcemaps-apply "^0.2.1"
+
+gulp-rename@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
+
 gulp-replace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gulp-replace/-/gulp-replace-1.0.0.tgz#b32bd61654d97b8d78430a67b3e8ce067b7c9143"
@@ -3581,6 +3604,18 @@ ignore@^3.3.5:
 ignore@^4.0.2, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+
+import-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
+  dependencies:
+    import-from "^2.1.0"
+
+import-from@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
+  dependencies:
+    resolve-from "^3.0.0"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -5692,6 +5727,13 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+postcss-load-config@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.0.0.tgz#f1312ddbf5912cd747177083c5ef7a19d62ee484"
+  dependencies:
+    cosmiconfig "^4.0.0"
+    import-cwd "^2.0.0"
+
 postcss-modules-extract-imports@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz#66140ecece38ef06bf0d3e355d69bf59d141ea85"
@@ -6158,6 +6200,10 @@ request@^2.87.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-from-string@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -7219,7 +7265,7 @@ vinyl-fs@^0.3.0:
     through2 "^0.6.1"
     vinyl "^0.4.0"
 
-vinyl-sourcemaps-apply@^0.2.0:
+vinyl-sourcemaps-apply@^0.2.0, vinyl-sourcemaps-apply@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
   dependencies:


### PR DESCRIPTION
It's been a massive pain trying to test whatever the current build of Autoprefixer is while it's been under development.

I've been resorting to opening the Autoprefixer repo, compiling it, copying the compiled assets into the node_modules folder of a completely unrelated project and then running the compiler for that project to get output CSS.

**That is an insane workflow!**

There needed to be an easier way to play around with the current Autoprefixer build and see if things are working as they are supposed to without having to go to all the trouble of creating formal tests.

So with that in mind I set up this simple little experimentation playground inside the Autoprefixer repo.

1. Run the command `gulp play`
2. Write some CSS in `playground.input.css` and save the file
3. View the output CSS in `playground.output.css`

For some reason it isn't translating CSS Grid code even though I've turned the setting on. @ai Do you have any idea why it isn't outputting CSS Grid code?