### PR TITLE
[Updated] Add warning to align/justify-items/content in IE

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -71,7 +71,7 @@ class Processor {
 
       let GridNeedsPrefixing = () => {
         let grid = this.prefixes.add['grid-area']
-        return this.prefixes.options.grid && grid
+        return this.prefixes.options.grid && grid && grid.prefixes
       }
 
       function isGrid (subDecl) {
@@ -107,23 +107,6 @@ class Processor {
                     'instead of display: box', { node: decl }
         )
         return undefined
-      } else if (isGridContainer() && GridNeedsPrefixing()) {
-        if (/(align|justify|place)-items/.test(prop)) {
-          let selfEquiv = decl.prop.replace('-items', '-self')
-          result.warn(['',
-            '  IE does not support align-items, justify-items, ' +
-              'or place-items on grid containers.',
-            '  Try using align-self or justify-self on child elements instead.',
-            `  Example: .grid > * { ${ selfEquiv }: ${ decl.value } }\n`
-          ].join('\n'), { node: decl })
-        }
-
-        if (/(align|justify|place)-content/.test(prop)) {
-          result.warn(
-            'IE does not support align-content, justify-content, or ' +
-            'place-content on grid containers.',
-            { node: decl })
-        }
       } else if (prop === 'text-emphasis-position') {
         if (value === 'under' || value === 'over') {
           result.warn(
@@ -133,8 +116,22 @@ class Processor {
           )
         }
       } else {
-        let grid = this.prefixes.add['grid-area']
-        if (this.prefixes.options.grid && grid && grid.prefixes) {
+        if (GridNeedsPrefixing()) {
+          if (isGridContainer()) {
+            if (/(align|justify|place)-items/.test(prop)) {
+              let selfEquiv = prop.replace('-items', '-self')
+              result.warn(['',
+                `  IE does not support ${ prop } on grid containers.`,
+                `  Try using ${ selfEquiv } on child elements instead.`,
+                `  Example: .grid > * { ${ selfEquiv }: ${ decl.value } }\n`
+              ].join('\n'), { node: decl })
+            }
+            if (/(align|justify|place)-content/.test(prop)) {
+              result.warn(
+                `IE does not support ${ decl.prop } on grid containers.'`,
+                { node: decl })
+            }
+          }
           if (prop === 'display' && decl.value === 'contents') {
             result.warn(
               'Please do not use display: contents; ' +

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -128,7 +128,7 @@ class Processor {
             }
             if (/(align|justify|place)-content/.test(prop)) {
               result.warn(
-                `IE does not support ${ decl.prop } on grid containers.'`,
+                `IE does not support ${ decl.prop } on grid containers.`,
                 { node: decl })
             }
           }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -69,7 +69,7 @@ class Processor {
       let prop = decl.prop
       let value = decl.value
 
-      function GridNeedsPrefixing () {
+      let GridNeedsPrefixing = () => {
         let grid = this.prefixes.add['grid-area']
         return this.prefixes.options.grid && grid
       }
@@ -85,7 +85,7 @@ class Processor {
 
       function isGridContainer () {
         return decl.parent.some(isGrid)
-      };
+      }
 
       if (prop === 'grid-row-span') {
         result.warn(

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -110,12 +110,11 @@ class Processor {
       } else if (isGridContainer() && GridNeedsPrefixing()) {
         if (/(align|justify|place)-items/.test(prop)) {
           let selfEquiv = decl.prop.replace('-items', '-self')
-          result.warn(['',
-            '  IE does not support align-items, justify-items, ' +
-              'or place-items on grid containers.',
-            '  Try using align-self or justify-self on child elements instead.',
-            `  Example: .grid > * { ${ selfEquiv }: ${ decl.value } }\n`
-          ].join('\n'), { node: decl })
+          result.warn('IE does not support align-items, justify-items, ' +
+              'or place-items on grid containers.' +
+            ' Try using align-self or justify-self on child elements instead.' +
+            ` Example: .grid > * { ${ selfEquiv }: ${ decl.value } }`,
+          { node: decl })
         }
 
         if (/(align|justify|place)-content/.test(prop)) {
@@ -141,37 +140,6 @@ class Processor {
               'if you have grid setting enabled',
               { node: decl }
             )
-          }
-          if (prop === 'grid-auto-columns') {
-            result.warn(
-              'grid-auto-columns is not supported by IE',
-              { node: decl }
-            )
-            return undefined
-          } else if (prop === 'grid-auto-rows') {
-            result.warn(
-              'grid-auto-rows is not supported by IE',
-              { node: decl }
-            )
-            return undefined
-          } else if (prop === 'grid-auto-flow') {
-            result.warn(
-              'grid-auto-flow is not supported by IE',
-              { node: decl }
-            )
-            return undefined
-          } else if (value.indexOf('auto-fit') !== -1) {
-            result.warn(
-              'auto-fit value is not supported by IE',
-              { node: decl, word: 'auto-fit' }
-            )
-            return undefined
-          } else if (value.indexOf('auto-fill') !== -1) {
-            result.warn(
-              'auto-fill value is not supported by IE',
-              { node: decl, word: 'auto-fill' }
-            )
-            return undefined
           }
         }
         if (value.indexOf('radial-gradient') !== -1) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -110,11 +110,12 @@ class Processor {
       } else if (isGridContainer() && GridNeedsPrefixing()) {
         if (/(align|justify|place)-items/.test(prop)) {
           let selfEquiv = decl.prop.replace('-items', '-self')
-          result.warn('IE does not support align-items, justify-items, ' +
-              'or place-items on grid containers.' +
-            ' Try using align-self or justify-self on child elements instead.' +
-            ` Example: .grid > * { ${ selfEquiv }: ${ decl.value } }`,
-          { node: decl })
+          result.warn(['',
+            '  IE does not support align-items, justify-items, ' +
+              'or place-items on grid containers.',
+            '  Try using align-self or justify-self on child elements instead.',
+            `  Example: .grid > * { ${ selfEquiv }: ${ decl.value } }\n`
+          ].join('\n'), { node: decl })
         }
 
         if (/(align|justify|place)-content/.test(prop)) {
@@ -140,6 +141,37 @@ class Processor {
               'if you have grid setting enabled',
               { node: decl }
             )
+          }
+          if (prop === 'grid-auto-columns') {
+            result.warn(
+              'grid-auto-columns is not supported by IE',
+              { node: decl }
+            )
+            return undefined
+          } else if (prop === 'grid-auto-rows') {
+            result.warn(
+              'grid-auto-rows is not supported by IE',
+              { node: decl }
+            )
+            return undefined
+          } else if (prop === 'grid-auto-flow') {
+            result.warn(
+              'grid-auto-flow is not supported by IE',
+              { node: decl }
+            )
+            return undefined
+          } else if (value.indexOf('auto-fit') !== -1) {
+            result.warn(
+              'auto-fit value is not supported by IE',
+              { node: decl, word: 'auto-fit' }
+            )
+            return undefined
+          } else if (value.indexOf('auto-fill') !== -1) {
+            result.warn(
+              'auto-fill value is not supported by IE',
+              { node: decl, word: 'auto-fill' }
+            )
+            return undefined
           }
         }
         if (value.indexOf('radial-gradient') !== -1) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -69,6 +69,24 @@ class Processor {
       let prop = decl.prop
       let value = decl.value
 
+      function GridNeedsPrefixing () {
+        let grid = this.prefixes.add['grid-area']
+        return this.prefixes.options.grid && grid
+      }
+
+      function isGrid (subDecl) {
+        let displayGrid = subDecl.prop === 'display' &&
+          /(inline-)?grid/.test(subDecl.value)
+        let gridTemplate = /grid-template/.test(subDecl.prop)
+        let gridGap = /grid-([A-z]+-)?gap/.test(subDecl.prop)
+
+        return displayGrid || gridTemplate || gridGap
+      }
+
+      function isGridContainer () {
+        return decl.parent.some(isGrid)
+      };
+
       if (prop === 'grid-row-span') {
         result.warn(
           'grid-row-span is not part of final Grid Layout. ' +
@@ -89,27 +107,28 @@ class Processor {
                     'instead of display: box', { node: decl }
         )
         return undefined
-      } else if (prop === 'display' && /grid|inline-grid/.test(value)) {
-        let testNeigbooursItems = /(align|justify)-items/
-        if (decl.parent.some(i => testNeigbooursItems.test(i.prop))) {
-          result.warn('IE does not support align-items and justify-items on ' +
-            'grid containers. You can use align-self and justify-self ' +
-            'insted. Often the easiest way to put align-self and justify-self' +
-            ' to .grid-selector > *',
-          { node: decl })
+      } else if (isGridContainer() && GridNeedsPrefixing()) {
+        if (/(align|justify|place)-items/.test(prop)) {
+          let selfEquiv = decl.prop.replace('-items', '-self')
+          result.warn(['',
+            '  IE does not support align-items, justify-items, ' +
+              'or place-items on grid containers.',
+            '  Try using align-self or justify-self on child elements instead.',
+            `  Example: .grid > * { ${ selfEquiv }: ${ decl.value } }\n`
+          ].join('\n'), { node: decl })
         }
 
-        let testNeigbooursContent = /(align|justify)-content/
-        if (decl.parent.some(i => testNeigbooursContent.test(i.prop))) {
-          result.warn('IE does not support align-content and justify-content ' +
-            'on grid containers.',
-          { node: decl })
+        if (/(align|justify|place)-content/.test(prop)) {
+          result.warn(
+            'IE does not support align-content, justify-content, or ' +
+            'place-content on grid containers.',
+            { node: decl })
         }
       } else if (prop === 'text-emphasis-position') {
         if (value === 'under' || value === 'over') {
           result.warn(
             'You should use 2 values for text-emphasis-position ' +
-                        'For example, `under left` instead of just `under`.',
+            'For example, `under left` instead of just `under`.',
             { node: decl }
           )
         }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -90,11 +90,19 @@ class Processor {
         )
         return undefined
       } else if (prop === 'display' && /grid|inline-grid/.test(value)) {
-        let testNeigboours = /(align|justify)-(content|items)/
+        let testNeigbooursItems = /(align|justify)-items/
+        if (decl.parent.some(i => testNeigbooursItems.test(i.prop))) {
+          result.warn('IE does not support align-items and justify-items on ' +
+            'grid containers. You can use align-self and justify-self ' +
+            'insted. Often the easiest way to put align-self and justify-self' +
+            ' to .grid-selector > *',
+          { node: decl })
+        }
 
-        if (decl.parent.some(i => testNeigboours.test(i.prop))) {
-          result.warn('IE does not support align-content, align-items,' +
-            ' justify-content and justify-items on grid containers',
+        let testNeigbooursContent = /(align|justify)-content/
+        if (decl.parent.some(i => testNeigbooursContent.test(i.prop))) {
+          result.warn('IE does not support align-content and justify-content ' +
+            'on grid containers.',
           { node: decl })
         }
       } else if (prop === 'text-emphasis-position') {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -89,6 +89,14 @@ class Processor {
                     'instead of display: box', { node: decl }
         )
         return undefined
+      } else if (prop === 'display' && /grid|inline-grid/.test(value)) {
+        let testNeigboours = /(align|justify)-(content|items)/
+
+        if (decl.parent.some(i => testNeigboours.test(i.prop))) {
+          result.warn('IE does not support align-content, align-items,' +
+            ' justify-content and justify-items on grid containers',
+          { node: decl })
+        }
       } else if (prop === 'text-emphasis-position') {
         if (value === 'under' || value === 'over') {
           result.warn(

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "size-limit": [
     {
       "path": "build/lib/autoprefixer.js",
-      "limit": "101 KB"
+      "limit": "102 KB"
     }
   ],
   "eslintConfig": {

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -543,30 +543,18 @@ describe('hacks', () => {
                 'of final Grid Layout. Use grid-column.',
       'autoprefixer: <css input>:100:3: grid-row-span is not part ' +
                 'of final Grid Layout. Use grid-row.',
-      'autoprefixer: <css input>:101:3: grid-auto-columns is not ' +
-                'supported by IE',
-      'autoprefixer: <css input>:102:3: grid-auto-rows is not ' +
-                'supported by IE',
-      'autoprefixer: <css input>:103:3: grid-auto-flow is not ' +
-                'supported by IE',
-      'autoprefixer: <css input>:104:33: auto-fill value is not ' +
-                'supported by IE',
-      'autoprefixer: <css input>:105:30: auto-fit value is not ' +
-                'supported by IE',
-      'autoprefixer: <css input>:121:3: Please do not use ' +
-      'display: contents; if you have grid setting enabled',
-      'autoprefixer: <css input>:126:3: IE does not support align-items and ' +
-                'justify-items on grid containers. ' +
-                'You can use align-self and justify-self insted. Often the ' +
-                'easiest way to put align-self and justify-self' +
-                ' to .grid-selector > *',
-      'autoprefixer: <css input>:131:3: IE does not support align-items and ' +
-                'justify-items on grid containers. ' +
-                'You can use align-self and justify-self insted. Often the ' +
-                'easiest way to put align-self and justify-self' +
-                ' to .grid-selector > *',
-      'autoprefixer: <css input>:136:3: IE does not support align-content ' +
-                'and justify-content on grid containers.'
+      'autoprefixer: <css input>:121:3: Please do not use display: contents; ' +
+                'if you have grid setting enabled',
+      'autoprefixer: <css input>:125:3: IE does not support align-items, ' +
+                'justify-items, or place-items on grid containers. ' +
+                'Try using align-self or justify-self on child elements ' +
+                'instead. Example: .grid > * { align-self: center }',
+      'autoprefixer: <css input>:130:3: IE does not support align-items, ' +
+                'justify-items, or place-items on grid containers. ' +
+      'Try using align-self or justify-self on child elements instead. ' +
+                'Example: .grid > * { justify-self: center }',
+      'autoprefixer: <css input>:135:3: IE does not support align-content, ' +
+                'justify-content, or place-content on grid containers.'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -563,9 +563,7 @@ describe('hacks', () => {
         '  IE does not support justify-items on grid containers.\n' +
         '  Try using justify-self on child elements instead.\n' +
         '  Example: .grid > * { justify-self: center }\n',
-      'autoprefixer: <css input>:135:3: IE does not support align-content ' +
-                'on grid containers.',
-      'autoprefixer: <css input>:140:3: IE does not support justify-content ' +
+      'autoprefixer: <css input>:135:3: IE does not support justify-content ' +
                 'on grid containers.'
     ])
   })

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -543,18 +543,30 @@ describe('hacks', () => {
                 'of final Grid Layout. Use grid-column.',
       'autoprefixer: <css input>:100:3: grid-row-span is not part ' +
                 'of final Grid Layout. Use grid-row.',
-      'autoprefixer: <css input>:121:3: Please do not use display: contents; ' +
-                'if you have grid setting enabled',
-      'autoprefixer: <css input>:125:3: IE does not support align-items, ' +
-                'justify-items, or place-items on grid containers. ' +
-                'Try using align-self or justify-self on child elements ' +
-                'instead. Example: .grid > * { align-self: center }',
-      'autoprefixer: <css input>:130:3: IE does not support align-items, ' +
-                'justify-items, or place-items on grid containers. ' +
-      'Try using align-self or justify-self on child elements instead. ' +
-                'Example: .grid > * { justify-self: center }',
-      'autoprefixer: <css input>:135:3: IE does not support align-content, ' +
-                'justify-content, or place-content on grid containers.'
+      'autoprefixer: <css input>:101:3: grid-auto-columns is not ' +
+                'supported by IE',
+      'autoprefixer: <css input>:102:3: grid-auto-rows is not ' +
+                'supported by IE',
+      'autoprefixer: <css input>:103:3: grid-auto-flow is not ' +
+                'supported by IE',
+      'autoprefixer: <css input>:104:33: auto-fill value is not ' +
+                'supported by IE',
+      'autoprefixer: <css input>:105:30: auto-fit value is not ' +
+                'supported by IE',
+      'autoprefixer: <css input>:121:3: Please do not use ' +
+      'display: contents; if you have grid setting enabled',
+      'autoprefixer: <css input>:126:3: IE does not support align-items and ' +
+                'justify-items on grid containers. ' +
+                'You can use align-self and justify-self insted. Often the ' +
+                'easiest way to put align-self and justify-self' +
+                ' to .grid-selector > *',
+      'autoprefixer: <css input>:131:3: IE does not support align-items and ' +
+                'justify-items on grid containers. ' +
+                'You can use align-self and justify-self insted. Often the ' +
+                'easiest way to put align-self and justify-self' +
+                ' to .grid-selector > *',
+      'autoprefixer: <css input>:136:3: IE does not support align-content ' +
+                'and justify-content on grid containers.'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -555,11 +555,11 @@ describe('hacks', () => {
                 'supported by IE',
       'autoprefixer: <css input>:121:3: Please do not use ' +
           'display: contents; if you have grid setting enabled',
-      'autoprefixer: <css input>:125:3:\n' +
+      'autoprefixer: <css input>:125:3: \n' +
         '  IE does not support align-items on grid containers.\n' +
         '  Try using align-self on child elements instead.\n' +
         '  Example: .grid > * { align-self: center }\n',
-      'autoprefixer: <css input>:130:3:\n' +
+      'autoprefixer: <css input>:130:3: \n' +
         '  IE does not support justify-items on grid containers.\n' +
         '  Try using justify-self on child elements instead.\n' +
         '  Example: .grid > * { justify-self: center }\n',

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -554,19 +554,17 @@ describe('hacks', () => {
       'autoprefixer: <css input>:105:30: auto-fit value is not ' +
                 'supported by IE',
       'autoprefixer: <css input>:121:3: Please do not use ' +
-      'display: contents; if you have grid setting enabled',
-      'autoprefixer: <css input>:126:3: IE does not support align-items and ' +
-                'justify-items on grid containers. ' +
-                'You can use align-self and justify-self insted. Often the ' +
-                'easiest way to put align-self and justify-self' +
-                ' to .grid-selector > *',
-      'autoprefixer: <css input>:131:3: IE does not support align-items and ' +
-                'justify-items on grid containers. ' +
-                'You can use align-self and justify-self insted. Often the ' +
-                'easiest way to put align-self and justify-self' +
-                ' to .grid-selector > *',
-      'autoprefixer: <css input>:136:3: IE does not support align-content ' +
-                'and justify-content on grid containers.'
+          'display: contents; if you have grid setting enabled',
+      'autoprefixer: <css input>:125:3:\n' +
+        '  IE does not support align-items on grid containers.\n' +
+        '  Try using align-self on child elements instead.\n' +
+        '  Example: .grid > * { align-self: center }\n',
+      'autoprefixer: <css input>:130:3:\n' +
+        '  IE does not support justify-items on grid containers.\n' +
+        '  Try using justify-self on child elements instead.\n' +
+        '  Example: .grid > * { justify-self: center }\n',
+      'autoprefixer: <css input>:140:3: IE does not support justify-content ' +
+                'on grid containers.'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -554,7 +554,10 @@ describe('hacks', () => {
       'autoprefixer: <css input>:105:30: auto-fit value is not ' +
                 'supported by IE',
       'autoprefixer: <css input>:121:3: Please do not use ' +
-      'display: contents; if you have grid setting enabled'
+      'display: contents; if you have grid setting enabled',
+      'autoprefixer: <css input>:126:3: IE does not support align-content, ' +
+                'align-items, justify-content and justify-items on ' +
+                'grid containers'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -555,9 +555,18 @@ describe('hacks', () => {
                 'supported by IE',
       'autoprefixer: <css input>:121:3: Please do not use ' +
       'display: contents; if you have grid setting enabled',
-      'autoprefixer: <css input>:126:3: IE does not support align-content, ' +
-                'align-items, justify-content and justify-items on ' +
-                'grid containers'
+      'autoprefixer: <css input>:126:3: IE does not support align-items and ' +
+                'justify-items on grid containers. ' +
+                'You can use align-self and justify-self insted. Often the ' +
+                'easiest way to put align-self and justify-self' +
+                ' to .grid-selector > *',
+      'autoprefixer: <css input>:131:3: IE does not support align-items and ' +
+                'justify-items on grid containers. ' +
+                'You can use align-self and justify-self insted. Often the ' +
+                'easiest way to put align-self and justify-self' +
+                ' to .grid-selector > *',
+      'autoprefixer: <css input>:136:3: IE does not support align-content ' +
+                'and justify-content on grid containers.'
     ])
   })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -563,6 +563,8 @@ describe('hacks', () => {
         '  IE does not support justify-items on grid containers.\n' +
         '  Try using justify-self on child elements instead.\n' +
         '  Example: .grid > * { justify-self: center }\n',
+      'autoprefixer: <css input>:135:3: IE does not support align-content ' +
+                'on grid containers.',
       'autoprefixer: <css input>:140:3: IE does not support justify-content ' +
                 'on grid containers.'
     ])

--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -131,6 +131,11 @@
   display: grid;
 }
 
+.warn_ie_align_content {
+  align-content: center;
+  display: grid;
+}
+
 .warn_ie_justify_content {
   justify-content: center;
   display: grid;

--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -121,17 +121,17 @@
   display: contents;
 }
 
-.warn_ei_align {
+.warn_ie_align {
   align-items: center;
   display: grid;
 }
 
-.warn_ei_justify {
+.warn_ie_justify {
   justify-items: center;
   display: grid;
 }
 
-.warn_ei_justify_content {
+.warn_ie_justify_content {
   justify-content: center;
   display: grid;
 }

--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -121,7 +121,17 @@
   display: contents;
 }
 
-.warn_ei {
+.warn_ei_align {
   align-items: center;
+  display: grid;
+}
+
+.warn_ei_justify {
+  justify-items: center;
+  display: grid;
+}
+
+.warn_ei_justify_content {
+  justify-content: center;
   display: grid;
 }

--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -120,3 +120,8 @@
 .warn-display-contents .grid {
   display: contents;
 }
+
+.warn_ei {
+  align-items: center;
+  display: grid;
+}

--- a/test/cases/grid.css
+++ b/test/cases/grid.css
@@ -131,11 +131,6 @@
   display: grid;
 }
 
-.warn_ie_align_content {
-  align-content: center;
-  display: grid;
-}
-
 .warn_ie_justify_content {
   justify-content: center;
   display: grid;

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -123,7 +123,7 @@
   display: contents;
 }
 
-.warn_ei_align {
+.warn_ie_align {
   -ms-flex-align: center;
       align-items: center;
   display: grid;

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -123,18 +123,18 @@
   display: contents;
 }
 
-.warn_ie_align {
+.warn_ei_align {
   -ms-flex-align: center;
       align-items: center;
   display: grid;
 }
 
-.warn_ie_justify {
+.warn_ei_justify {
   justify-items: center;
   display: grid;
 }
 
-.warn_ie_justify_content {
+.warn_ei_justify_content {
   -ms-flex-pack: center;
       justify-content: center;
   display: grid;

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -122,3 +122,9 @@
 .warn-display-contents .grid {
   display: contents;
 }
+
+.warn_ei {
+  -ms-flex-align: center;
+      align-items: center;
+  display: grid;
+}

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -123,18 +123,18 @@
   display: contents;
 }
 
-.warn_ei_align {
+.warn_ie_align {
   -ms-flex-align: center;
       align-items: center;
   display: grid;
 }
 
-.warn_ei_justify {
+.warn_ie_justify {
   justify-items: center;
   display: grid;
 }
 
-.warn_ei_justify_content {
+.warn_ie_justify_content {
   -ms-flex-pack: center;
       justify-content: center;
   display: grid;

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -129,12 +129,12 @@
   display: grid;
 }
 
-.warn_ei_justify {
+.warn_ie_justify {
   justify-items: center;
   display: grid;
 }
 
-.warn_ei_justify_content {
+.warn_ie_justify_content {
   -ms-flex-pack: center;
       justify-content: center;
   display: grid;

--- a/test/cases/grid.disabled.css
+++ b/test/cases/grid.disabled.css
@@ -123,8 +123,19 @@
   display: contents;
 }
 
-.warn_ei {
+.warn_ei_align {
   -ms-flex-align: center;
       align-items: center;
+  display: grid;
+}
+
+.warn_ei_justify {
+  justify-items: center;
+  display: grid;
+}
+
+.warn_ei_justify_content {
+  -ms-flex-pack: center;
+      justify-content: center;
   display: grid;
 }

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -159,3 +159,11 @@
 .warn-display-contents .grid {
   display: contents;
 }
+
+.warn_ei {
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -ms-grid;
+  display: grid;
+}

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -160,7 +160,7 @@
   display: contents;
 }
 
-.warn_ei_align {
+.warn_ie_align {
   -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
@@ -168,13 +168,13 @@
   display: grid;
 }
 
-.warn_ei_justify {
+.warn_ie_justify {
   justify-items: center;
   display: -ms-grid;
   display: grid;
 }
 
-.warn_ei_justify_content {
+.warn_ie_justify_content {
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -160,10 +160,24 @@
   display: contents;
 }
 
-.warn_ei {
+.warn_ei_align {
   -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  display: -ms-grid;
+  display: grid;
+}
+
+.warn_ei_justify {
+  justify-items: center;
+  display: -ms-grid;
+  display: grid;
+}
+
+.warn_ei_justify_content {
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   display: -ms-grid;
   display: grid;
 }

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -175,8 +175,8 @@
 }
 
 .warn_ie_align_content {
-  -webkit-align-content: center;
   -ms-flex-line-pack: center;
+  -webkit-align-content: center;
   align-content: center;
   display: -ms-grid;
   display: grid;

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -137,9 +137,7 @@
   grid-auto-columns: 100px;
   grid-auto-rows: 100px;
   grid-auto-flow: column;
-  -ms-grid-columns: (minmax(400px, 1fr))[auto-fill];
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  -ms-grid-rows: (minmax(400px, 1fr))[auto-fit];
   grid-template-rows: repeat(auto-fit, minmax(400px, 1fr));
 }
 
@@ -172,6 +170,14 @@
 
 .warn_ie_justify {
   justify-items: center;
+  display: -ms-grid;
+  display: grid;
+}
+
+.warn_ie_align_content {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
   display: -ms-grid;
   display: grid;
 }

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -174,6 +174,12 @@
   display: grid;
 }
 
+.warn_ie_align_content {
+  align-content: center;
+  display: -ms-grid;
+  display: grid;
+}
+
 .warn_ie_justify_content {
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -137,7 +137,9 @@
   grid-auto-columns: 100px;
   grid-auto-rows: 100px;
   grid-auto-flow: column;
+  -ms-grid-columns: (minmax(400px, 1fr))[auto-fill];
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  -ms-grid-rows: (minmax(400px, 1fr))[auto-fit];
   grid-template-rows: repeat(auto-fit, minmax(400px, 1fr));
 }
 
@@ -170,14 +172,6 @@
 
 .warn_ie_justify {
   justify-items: center;
-  display: -ms-grid;
-  display: grid;
-}
-
-.warn_ie_align_content {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
   display: -ms-grid;
   display: grid;
 }

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -175,6 +175,8 @@
 }
 
 .warn_ie_align_content {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
   align-content: center;
   display: -ms-grid;
   display: grid;

--- a/test/cases/grid.out.css
+++ b/test/cases/grid.out.css
@@ -174,14 +174,6 @@
   display: grid;
 }
 
-.warn_ie_align_content {
-  -ms-flex-line-pack: center;
-  -webkit-align-content: center;
-  align-content: center;
-  display: -ms-grid;
-  display: grid;
-}
-
 .warn_ie_justify_content {
   -webkit-justify-content: center;
   -ms-flex-pack: center;


### PR DESCRIPTION
This is a branch off of https://github.com/postcss/autoprefixer/pull/1123 by @janczer.

It fixes https://github.com/postcss/autoprefixer/pull/1123 (`align/justify-items/content` warnings).

Our branches got out of sync and it was too difficult to merge them back together so I'm just making a new pull request instead.

Further discussion is in https://github.com/postcss/autoprefixer/pull/1123