### PR TITLE
Setting up a VS Code debugger launch.json config file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Gulp play",
+			"program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
+			"args": [
+				"play"
+			]
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Gulp build",
+			"program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
+			"args": [
+				"build"
+			]
+		}
+	]
+}


### PR DESCRIPTION
This makes it immensly easier to debug autoprefixer bugs in VS Code because you can set up break points and have them trigger while running the `gulp play` task.

To take advantage of this, add some breakpoints to one of the core Autoprefixer js files.

![VS-Code Break JS point](https://user-images.githubusercontent.com/10610368/48661026-d2239300-eabf-11e8-8a04-20a779d739d5.png)

Now go to the Debug panel and make sure that "Gulp play" is the selected debug option (it should be selected by default).

![Debug panel button and the "Gulp play" debug option](https://user-images.githubusercontent.com/10610368/48661041-13b43e00-eac0-11e8-8a8b-36362d8774e5.png)

Click the green play button.

![Green play button](https://user-images.githubusercontent.com/10610368/48661054-4eb67180-eac0-11e8-93c0-8f9310b56ab5.png)

You are now running the `gulp play` task in debug mode. Gulp will function the same as if you typed `gulp play` directly into the terminal with the key exception being that the code will pause execution wherever you have placed breakpoints making bugs immensely easier to debug.

I've also added the default `gulp build` task into the config file as an extra option if you don't want the debugger process to run continuously once started.

(@bogdan0083 Merry Christmas 😜)