### PR TITLE
Add warning for some content-distribution and alignement properties

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -87,6 +87,12 @@ class Processor {
         return displayGrid || gridTemplate || gridGap
       })
     }
+    function insideFlex (decl) {
+      return decl.parent.some(
+        subDecl =>
+          subDecl.prop === 'display' && /(inline-)?flex/.test(subDecl.value)
+      )
+    }
 
     let gridPrefixes = this.gridStatus(css, result) &&
                        this.prefixes.add['grid-area'] &&
@@ -122,6 +128,17 @@ class Processor {
           result.warn(
             'You should use 2 values for text-emphasis-position ' +
             'For example, `under left` instead of just `under`.',
+            { node: decl }
+          )
+        }
+      } else if (
+        /^(align|justify|place)-(items|content)$/.test(prop) &&
+        insideFlex(decl)
+      ) {
+        if (value === 'start' || value === 'end') {
+          result.warn(
+            `${ value } value has mixed support, consider using ` +
+              `flex-${ value } instead`,
             { node: decl }
           )
         }

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -547,6 +547,23 @@ describe('hacks', () => {
     ])
   })
 
+  it('warns on mixed support usage', () => {
+    let css =
+      'a { display: flex; align-content: start; justify-content: end; }'
+    let result = postcss([
+      autoprefixer({
+        browsers: ['IE 11']
+      })
+    ]).process(css)
+    expect(result.css).toEqual(css)
+    expect(result.warnings().map(i => i.toString())).toEqual([
+      'autoprefixer: <css input>:1:20: start value has mixed support, ' +
+        'consider using flex-start instead',
+      'autoprefixer: <css input>:1:42: end value has mixed support, ' +
+        'consider using flex-end instead'
+    ])
+  })
+
   it('supports intrinsic sizing', () => {
     let input = read('intrinsic')
     let output = read('intrinsic.out')


### PR DESCRIPTION
The values `start` and `end` for the properties `justify-content` and `align-content` has [mixed support in Flexbox layout](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#Support_in_Flex_layout) and behave the same as `flex-start` and `flex-end`. This PR warns the user the Flexbox specific value has better support and should be preferred.

Fixes: https://github.com/postcss/autoprefixer/issues/1170