### PR TITLE
Gulp 4 code fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,13 @@
 let gulp = require('gulp')
-let path = require('path')
 let fs = require('fs-extra')
 let postcss = require('gulp-postcss')
 let rename = require('gulp-rename')
 
+function join (...folderPath) { return folderPath.join('/') }
+
 gulp.task('clean', done => {
-  fs.remove(path.join(__dirname, 'autoprefixer.js'), () => {
-    fs.remove(path.join(__dirname, 'build'), done)
+  fs.remove(join(__dirname, 'autoprefixer.js'), () => {
+    fs.remove(join(__dirname, 'build'), done)
   })
 })
 
@@ -58,7 +59,7 @@ gulp.task('build',
 
 gulp.task('standalone', gulp.series('clean', 'build:lib', done => {
   let builder = require('browserify')({
-    basedir: path.join(__dirname, 'build'),
+    basedir: join(__dirname, 'build'),
     standalone: 'autoprefixer'
   })
   builder.add('./lib/autoprefixer.js')
@@ -80,14 +81,14 @@ gulp.task('standalone', gulp.series('clean', 'build:lib', done => {
     .bundle((error, build) => {
       if (error) throw error
 
-      fs.removeSync(path.join(__dirname, 'build'))
+      fs.removeSync(join(__dirname, 'build'))
 
-      let rails = path.join(__dirname, '..', 'autoprefixer-rails',
+      let rails = join(__dirname, '..', 'autoprefixer-rails',
         'vendor', 'autoprefixer.js')
       if (fs.existsSync(rails)) {
         fs.writeFileSync(rails, build)
       } else {
-        let out = path.join(__dirname, 'autoprefixer.js')
+        let out = join(__dirname, 'autoprefixer.js')
         fs.writeFileSync(out, build)
       }
       done()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,8 +54,10 @@ gulp.task('build:package', () => {
     .pipe(gulp.dest('build'))
 })
 
-gulp.task('build',
-  gulp.series('clean', 'build:lib', 'build:docs', 'build:bin', 'build:package'))
+gulp.task('build', gulp.series(
+  'clean',
+  gulp.parallel('build:lib', 'build:docs', 'build:bin', 'build:package')
+))
 
 gulp.task('standalone', gulp.series('clean', 'build:lib', done => {
   let builder = require('browserify')({
@@ -103,16 +105,12 @@ gulp.task('compile-playground', () => {
     .pipe(gulp.dest('./playground'))
 })
 
-gulp.task('initialise-playground', gulp.series('build', () => {
-  return gulp.start('compile-playground')
-}))
+gulp.task('initialise-playground', gulp.series('build', 'compile-playground'))
 
 gulp.task('watch-playground', () => {
-  return gulp.watch('./playground/input.css', ['compile-playground'])
+  return gulp.watch('./playground/input.css', gulp.series('compile-playground'))
 })
 
-gulp.task('play', gulp.series('initialise-playground', () => {
-  gulp.start('watch-playground')
-}))
+gulp.task('play', gulp.series('initialise-playground', 'watch-playground'))
 
 gulp.task('default', gulp.series('build'))


### PR DESCRIPTION
There were some issues with the Gulp 4 code. This pull request fixes those issues.

- Replaced `path.join()` with a `join()` function (`path.join()` doesn't work properly in Gulp 4)
- It now runs `'build:lib'`, `'build:docs'`, `'build:bin'`, and `'build:package'` all in parallel rather than one after the other for a faster compile time.
- Replaced the old `gulp.start()` commands (not a valid syntax in Gulp 4) with proper `gulp.series()` syntax.
- Fixed the `"watch-playground"` Gulp task syntax.