### PR TITLE
Fix tests for OS Windows

### DIFF
--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -140,8 +140,9 @@ function check (from, instance = prefixer(from)) {
   let input = read(from)
   let output = read(from + '.out')
   let result = postcss([instance]).process(input)
+  function universalizer (string) { return string.split('\r').join('') }
   expect(result.warnings()).toHaveLength(0)
-  expect(result.css).toEqual(output)
+  expect(universalizer(result.css)).toEqual(universalizer(output))
 }
 
 const COMMONS = [
@@ -331,11 +332,13 @@ it('does not add prefixes on request', () => {
 })
 
 it('prevents doubling prefixes', () => {
+  function universalizer (string) { return string.split('\r').join('') }
   for (let type of COMMONS) {
     let processor = postcss([prefixer(type)])
     let input = read(type)
     let output = read(type + '.out')
-    expect(processor.process(processor.process(input)).css).toEqual(output)
+    let result = processor.process(processor.process(input)).css
+    expect(universalizer(result)).toEqual(universalizer(output))
   }
 })
 

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -136,11 +136,14 @@ function read (name) {
   return fs.readFileSync(file).toString()
 }
 
+function universalizer (string) {
+  return string.split('\r').join('')
+}
+
 function check (from, instance = prefixer(from)) {
   let input = read(from)
   let output = read(from + '.out')
   let result = postcss([instance]).process(input)
-  function universalizer (string) { return string.split('\r').join('') }
   expect(result.warnings()).toHaveLength(0)
   expect(universalizer(result.css)).toEqual(universalizer(output))
 }
@@ -332,7 +335,6 @@ it('does not add prefixes on request', () => {
 })
 
 it('prevents doubling prefixes', () => {
-  function universalizer (string) { return string.split('\r').join('') }
   for (let type of COMMONS) {
     let processor = postcss([prefixer(type)])
     let input = read(type)


### PR DESCRIPTION
According to issue #1203 
Excludes '\r' symbol, tests compare uniform values of `output` and `result` variables.