### PR TITLE
Fix link to PostCSS warning API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ result.warnings().forEach(warn => {
 
 Every Autoprefixer runner should display these warnings.
 
-[PostCSS warning API]: https://github.com/postcss/postcss/blob/master/docs/api.md#warning-class
+[PostCSS warning API]: http://api.postcss.org/Warning.html
 
 
 ## Disabling


### PR DESCRIPTION
The PostCSS documentation has moved, and this link moved with it. I believe this is the new page for the `Warning` class. Thanks for the great library!