### PR TITLE
chore: swap color lib

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -1,7 +1,7 @@
 let browserslist = require('browserslist')
 let postcss = require('postcss')
 let agents = require('caniuse-lite').agents
-let chalk = require('chalk')
+let kleur = require('kleur/colors')
 
 let Browsers = require('./browsers')
 let Prefixes = require('./prefixes')
@@ -79,10 +79,10 @@ module.exports = postcss.plugin('autoprefixer', (...reqs) => {
     reqs = options.overrideBrowserslist
   } else if (options.browsers) {
     if (typeof console !== 'undefined' && console.warn) {
-      if (chalk && chalk.red) {
+      if (kleur.red) {
         console.warn(
-          chalk.red(
-            WARNING.replace(/`[^`]+`/g, i => chalk.yellow(i.slice(1, -1)))
+          kleur.red(
+            WARNING.replace(/`[^`]+`/g, i => kleur.yellow(i.slice(1, -1)))
           )
         )
       } else {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/register": "^7.9.0",
     "browserslist": "^4.12.0",
     "caniuse-lite": "^1.0.30001061",
-    "chalk": "^2.4.2",
+    "kleur": "^4.0.0",
     "normalize-range": "^0.1.2",
     "num2fraction": "^1.2.2",
     "postcss": "^7.0.30",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/register": "^7.9.0",
     "browserslist": "^4.12.0",
     "caniuse-lite": "^1.0.30001061",
-    "kleur": "^4.0.0",
+    "kleur": "^4.0.1",
     "normalize-range": "^0.1.2",
     "num2fraction": "^1.2.2",
     "postcss": "^7.0.30",

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -1,8 +1,8 @@
-jest.doMock('chalk', () => ({ }))
+jest.doMock('kleur/colors', () => ({ }))
 
 let autoprefixer = require('../lib/autoprefixer')
 
-it('works without chalk', () => {
+it('works without kleur', () => {
   jest.spyOn(console, 'warn').mockImplementation(() => true)
   let instance = autoprefixer({ browsers: ['last 1 version'] })
   expect(instance.browsers).toEqual(['last 1 version'])


### PR DESCRIPTION
Now uses the same, small color library as postcss (recently updated). 
Made sure to use the same `kleur/colors` variant so that the same file is loaded/reused.

You were surprisingly using `chalk@^2.4`, which is/was a different version than the `postcss@^7.0.30` range used, so users were juggling two copies of chalk in their dependency tree.

Performance numbers, comparing `kleur/colors` to `chalk@2.4`

```
# All Colors
  chalk@2.4        x  12,373 ops/sec ±2.19%
  kleur/colors     x 862,421 ops/sec ±0.19%

# Stacked colors
  chalk@2.4        x   2,690 ops/sec ±2.32%
  kleur/colors     x 103,509 ops/sec ±0.30%

# Nested colors
  chalk@2.4        x   5,882 ops/sec ±1.34%
  kleur/colors     x 143,956 ops/sec ±0.25%
```