### PR TITLE
Change log fix for v9.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 9.8.5
 * Improved Grid Layout warnings (by Daniel Tonon).
+* Fix for align/justify-self grid prefixes not getting applied if the grid item is set to `display: flex` (by Daniel Tonon).
 
 ## 9.8.4
 * Replace color output library.


### PR DESCRIPTION
I'll need you to update the [release page for v9.8.5](https://github.com/postcss/autoprefixer/releases/tag/9.8.5).

Why have this change-log file anyway? Can't you just link to the [releases page in GitHub](https://github.com/postcss/autoprefixer/releases)?