### PR TITLE
Simplify uniq util

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,13 +15,7 @@ module.exports = {
    * Return array, that doesn’t contain duplicates.
    */
   uniq (array) {
-    let filtered = []
-    for (let i of array) {
-      if (!filtered.includes(i)) {
-        filtered.push(i)
-      }
-    }
-    return filtered
+    return [...new Set(array)]
   },
 
   /**


### PR DESCRIPTION
Simplify `uniq(array)` util with `Set` & spread syntax. All tests are passed.

`Set` is supported since Node.js 0.13 while spread syntax is fully supported since Node.js 8.3.0.

