### PR TITLE
Refactor cache into Map

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -26,7 +26,7 @@ function isPlainObject (obj) {
   return Object.prototype.toString.apply(obj) === '[object Object]'
 }
 
-let cache = {}
+let cache = new Map()
 
 function timeCapsule (result, prefixes) {
   if (prefixes.browsers.selected.length === 0) {
@@ -103,11 +103,11 @@ module.exports = (...reqs) => {
     let browsers = new Browsers(d.browsers, reqs, opts, brwlstOpts)
     let key = browsers.selected.join(', ') + JSON.stringify(options)
 
-    if (!cache[key]) {
-      cache[key] = new Prefixes(d.prefixes, browsers, options)
+    if (!cache.has(key)) {
+      cache.set(key, new Prefixes(d.prefixes, browsers, options))
     }
 
-    return cache[key]
+    return cache.get(key)
   }
 
   return {

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -65,7 +65,7 @@ Value.hack(require('./hacks/display-flex'))
 Value.hack(require('./hacks/display-grid'))
 Value.hack(require('./hacks/filter-value'))
 
-let declsCache = {}
+let declsCache = new Map()
 
 class Prefixes {
   constructor (data, browsers, options = {}) {
@@ -267,14 +267,11 @@ class Prefixes {
    * Declaration loader with caching
    */
   decl (prop) {
-    let decl = declsCache[prop]
-
-    if (decl) {
-      return decl
-    } else {
-      declsCache[prop] = Declaration.load(prop)
-      return declsCache[prop]
+    if (!declsCache.has(prop)) {
+      declsCache.set(prop, Declaration.load(prop))
     }
+
+    return declsCache.get(prop)
   }
 
   /**

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -8,7 +8,7 @@ let utils = require('./utils')
 class Selector extends Prefixer {
   constructor (name, prefixes, all) {
     super(name, prefixes, all)
-    this.regexpCache = {}
+    this.regexpCache = new Map()
   }
 
   /**
@@ -33,16 +33,15 @@ class Selector extends Prefixer {
    * Lazy loadRegExp for name
    */
   regexp (prefix) {
-    if (this.regexpCache[prefix]) {
-      return this.regexpCache[prefix]
+    if (!this.regexpCache.has(prefix)) {
+      let name = prefix ? this.prefixed(prefix) : this.name
+      this.regexpCache.set(
+        prefix,
+        new RegExp(`(^|[^:"'=])${utils.escapeRegexp(name)}`, 'gi')
+      )
     }
 
-    let name = prefix ? this.prefixed(prefix) : this.name
-    this.regexpCache[prefix] = new RegExp(
-      `(^|[^:"'=])${utils.escapeRegexp(name)}`,
-      'gi'
-    )
-    return this.regexpCache[prefix]
+    return this.regexpCache.get(prefix)
   }
 
   /**


### PR DESCRIPTION
`Map` provides methods like `get`, `set` & `has` that is more intuitive for caching.

Also, [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) suggests that:

> (Map) performs better in scenarios involving frequent additions and removals of key-value pairs, (while Object is) not optimized for frequent additions and removals of key-value pairs.

`Map` is supported since Node.js 0.12.0.

All tests are passed for the PR.