### PR TITLE
Refactor: introduce a cache util

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -6,6 +6,7 @@ let Browsers = require('./browsers')
 let Prefixes = require('./prefixes')
 let data = require('../data/prefixes')
 let info = require('./info')
+let { Cache } = require('./utils')
 
 const WARNING =
   '\n' +
@@ -26,7 +27,7 @@ function isPlainObject (obj) {
   return Object.prototype.toString.apply(obj) === '[object Object]'
 }
 
-let cache = new Map()
+let cache = new Cache()
 
 function timeCapsule (result, prefixes) {
   if (prefixes.browsers.selected.length === 0) {
@@ -103,11 +104,7 @@ module.exports = (...reqs) => {
     let browsers = new Browsers(d.browsers, reqs, opts, brwlstOpts)
     let key = browsers.selected.join(', ') + JSON.stringify(options)
 
-    if (!cache.has(key)) {
-      cache.set(key, new Prefixes(d.prefixes, browsers, options))
-    }
-
-    return cache.get(key)
+    return cache.apply(key, new Prefixes(d.prefixes, browsers, options))
   }
 
   return {

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -65,7 +65,7 @@ Value.hack(require('./hacks/display-flex'))
 Value.hack(require('./hacks/display-grid'))
 Value.hack(require('./hacks/filter-value'))
 
-let declsCache = new Map()
+let declsCache = new utils.Cache()
 
 class Prefixes {
   constructor (data, browsers, options = {}) {
@@ -267,11 +267,7 @@ class Prefixes {
    * Declaration loader with caching
    */
   decl (prop) {
-    if (!declsCache.has(prop)) {
-      declsCache.set(prop, Declaration.load(prop))
-    }
-
-    return declsCache.get(prop)
+    return declsCache.apply(prop, Declaration.load(prop))
   }
 
   /**

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -8,7 +8,7 @@ let utils = require('./utils')
 class Selector extends Prefixer {
   constructor (name, prefixes, all) {
     super(name, prefixes, all)
-    this.regexpCache = new Map()
+    this.regexpCache = new utils.Cache()
   }
 
   /**
@@ -33,15 +33,10 @@ class Selector extends Prefixer {
    * Lazy loadRegExp for name
    */
   regexp (prefix) {
-    if (!this.regexpCache.has(prefix)) {
+    return this.regexpCache.apply(prefix, () => {
       let name = prefix ? this.prefixed(prefix) : this.name
-      this.regexpCache.set(
-        prefix,
-        new RegExp(`(^|[^:"'=])${utils.escapeRegexp(name)}`, 'gi')
-      )
-    }
-
-    return this.regexpCache.get(prefix)
+      return new RegExp(`(^|[^:"'=])${utils.escapeRegexp(name)}`, 'gi')
+    })
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,25 @@
 let { list } = require('postcss')
 
+class Cache {
+  constructor () {
+    this.map = new Map()
+  }
+
+  /**
+   * Retrieve from the cache if has been cached
+   * Otherwise save it to the cache
+   */
+  apply (key, value) {
+    if (this.map.has(key)) return this.map.get(key)
+
+    // Cache the return value of the function instead of the function itself
+    if (typeof value === 'function') value = value()
+
+    this.map.set(key, value)
+    return value
+  }
+}
+
 module.exports = {
   /**
    * Throw special error, to tell beniary,
@@ -76,5 +96,7 @@ module.exports = {
         return k.split(/(?=\.|#)/g)
       })
     })
-  }
+  },
+
+  Cache
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@ let { list } = require('postcss')
 
 class Cache {
   constructor () {
+    // FIXME: private class field is supported for Node.js 12 and newer
     this.map = new Map()
   }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -122,3 +122,21 @@ describe('.splitSelector()', () => {
     ])
   })
 })
+
+describe('.Cache', () => {
+  it('cache the key-value pair', () => {
+    let cache = new utils.Cache()
+
+    expect(cache.apply('123', '456')).toEqual('456')
+
+    // "123 => 456" shouldn't be overrided by "123 => 789" as it has been cached
+    expect(cache.apply('123', '789')).toEqual('456')
+  })
+
+  it('cache the return value of given function', () => {
+    let cache = new utils.Cache()
+
+    expect(cache.apply('123', () => '456')).toEqual('456')
+    expect(cache.apply('123', '789')).toEqual('456')
+  })
+})


### PR DESCRIPTION
The PR brings up the `Cache` util to reuse the code.

All tests are passed. The coverage of `util.js` remains 100%.