### PR TITLE
Fix Cannot read property 'proxyOf' of undefined exception from PostCSS

### DIFF
--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -511,7 +511,15 @@ function insertAreas (css, isDisabled) {
 
       // if we can't find the area name, update lastRule and continue
       if (!area) {
-        let lastRuleIndex = css.index(rulesToInsert[lastArea].lastRule)
+        let lastRule = rulesToInsert[lastArea].lastRule
+        let lastRuleIndex
+        if (lastRule) {
+          lastRuleIndex = css.index(lastRule)
+        } else {
+          /* istanbul ignore next */
+          lastRuleIndex = -1
+        }
+
         if (gridAreaRuleIndex > lastRuleIndex) {
           rulesToInsert[lastArea].lastRule = gridAreaMedia || gridAreaRule
         }


### PR DESCRIPTION
Hello!

Yesterday I tried to migrate https://aviasales.com to PostCSS 8 and Autoprefixer 10 and I found a problem, but I couldn't locate it. @ai show me the place, and I fix it.

https://github.com/postcss/postcss/pull/1473

I thinks, code of this PR is kind of dirty, maybe we should change `index()` method signature and return `-1`, if someone pass something unexpected (exactly as `Array#indexOf` works)?

Actually, I still can not reproduce this error in test-env (it is the reason, why I did not write any new tests), because I do not really understand how this case can be possible. I write this code like a monkey, sorry 🤣