### PR TITLE
fixed misspelling of "subtract" for mask-composite

### DIFF
--- a/lib/hacks/mask-composite.js
+++ b/lib/hacks/mask-composite.js
@@ -73,7 +73,7 @@ MaskComposite.names = ['mask', 'mask-composite']
 
 MaskComposite.oldValues = {
   add: 'source-over',
-  substract: 'source-out',
+  subtract: 'source-out',
   intersect: 'source-in',
   exclude: 'xor'
 }

--- a/test/cases/mask-composite.css
+++ b/test/cases/mask-composite.css
@@ -19,5 +19,5 @@ a {
 }
 
 a {
-  mask-composite: add, substract, exclude;
+  mask-composite: add, subtract, exclude;
 }

--- a/test/cases/mask-composite.out.css
+++ b/test/cases/mask-composite.out.css
@@ -27,5 +27,5 @@ a {
 
 a {
   -webkit-mask-composite: source-over, source-out, xor;
-          mask-composite: add, substract, exclude;
+          mask-composite: add, subtract, exclude;
 }


### PR DESCRIPTION
Just changed "substract" to "subtract" so `mask-composite: subtract` outputs `-webkit-mask-composite: source-out`