### PR TITLE
Fix error throwing when `supports-selector-fn` has pseudo-classes or pseudo-elements as argument.

### DIFF
--- a/lib/supports.js
+++ b/lib/supports.js
@@ -223,10 +223,18 @@ class Supports {
     }
 
     nodes = nodes.filter(i => i !== '')
-    if (typeof nodes[0] === 'string' && nodes[0].includes(':')) {
-      return [brackets.stringify(nodes)]
-    }
 
+    if (typeof nodes[0] === 'string') {
+      let firstNode = nodes[0].trim()
+
+      if (
+        firstNode.includes(':') ||
+        firstNode === 'selector' ||
+        firstNode === 'not selector'
+      ) {
+        return [brackets.stringify(nodes)]
+      }
+    }
     return nodes.map(i => this.normalize(i))
   }
 

--- a/test/supports.test.js
+++ b/test/supports.test.js
@@ -155,4 +155,18 @@ describe('process()', () => {
     supports.process(rule)
     expect(rule.params).toEqual('(color black) and not ((-moz-a: 1) or (a: 1))')
   })
+
+  it("shouldn't throw errors", () => {
+    let rule = { params: 'not selector(:is(a, b))' }
+    supports.process(rule)
+    expect(rule.params).toEqual('not selector(:is(a, b))')
+  })
+
+  it("shouldn't throw errors (2)", () => {
+    let rule = { params: ' (selector( :nth-child(1n of a, b) )) or (c: b(1)) ' }
+    supports.process(rule)
+    expect(rule.params).toEqual(
+      ' (selector( :nth-child(1n of a, b) )) or ((c: -moz-b(1)) or (c: b(1))) '
+    )
+  })
 })


### PR DESCRIPTION
Related to #1391
