### PR TITLE
update postcss to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fs-extra": "^9.1.0",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
-    "postcss": "^8.2.8",
+    "postcss": "^8.2.15",
     "prettier": "^2.2.1",
     "simple-git-hooks": "^2.0.2",
     "size-limit": "^4.10.1",


### PR DESCRIPTION
`postcss` from 7.0.0 and before 8.2.10 are vulnerable to Regular Expression Denial of Service (ReDoS) during source map parsing, as stated in this advisory: https://www.npmjs.com/advisories/1693 
This PR seeks to update the postcss package to a patched version. 