### PR TITLE
Clarify warning about no targets

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -43,9 +43,13 @@ function timeCapsule(result, prefixes) {
 
   /* istanbul ignore next */
   result.warn(
-    'Greetings, time traveller. ' +
-      'We are in the golden age of prefix-less CSS, ' +
-      'where Autoprefixer is no longer needed for your stylesheet.'
+    'Autoprefixer applied with no browsers, prefixes or selectors in the target list. ' +
+    'This is redundant, and no prefixes will be applied. ' +
+    'Make sure your targets are set up correctly.\n' +
+    '\n' +
+    '  Learn more at:\n' +
+    '  https://github.com/postcss/autoprefixer#readme\n'
+    '\n'
   )
 }
 

--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -48,7 +48,7 @@ function timeCapsule(result, prefixes) {
     'Make sure your targets are set up correctly.\n' +
     '\n' +
     '  Learn more at:\n' +
-    '  https://github.com/postcss/autoprefixer#readme\n'
+    '  https://github.com/postcss/autoprefixer#readme\n' +
     '\n'
   )
 }


### PR DESCRIPTION
Due to user error or outdated scripts, users may be warned about no prefixes being applied.
Rewrite this error message to be more understandable.

This should help with #1318 