### PR TITLE
Add support for mask-position-x and mask-position-y

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -699,6 +699,8 @@ f(prefixCssMasks, browsers => {
     [
       'mask',
       'mask-position',
+      'mask-position-x',
+      'mask-position-y',
       'mask-size',
       'mask-border',
       'mask-border-outset',


### PR DESCRIPTION
Closes #1245 

Despite this not being mentioned in the CSS Masking spec, I think there's good enough reason to add them.
It's unlikely the final spec won't include them (even if for nothing other than compat reasons) considering there's direct prefixed counterparts and and they're implemented in Firefox already ([demo](https://jsfiddle.net/jbyoLu26/) for testing in Firefox).