### PR TITLE
Add bugs field/URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",
   "repository": "postcss/autoprefixer",
+  "bugs": {
+    "url": "https://github.com/postcss/autoprefixer/issues"
+  },
   "peerDependencies": {
     "postcss": "^8.1.0"
   },


### PR DESCRIPTION
Useful for contributors to quickly go to GitHub after they've cloned the repo.

Similar to how it's done at: https://github.com/postcss/postcss/blob/e2f59d057f30d419e8fa7fac0095d3a47795714d/package.json#L66