### PR TITLE
Use caniuse-lite data for `::file-selector-button`

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -522,23 +522,15 @@ f(prefixFullscreen, { match: /x(\s#2|$)/ }, browsers =>
 )
 
 // File selector button
-prefix(['::file-selector-button'], {
-  selector: true,
-  feature: 'file-selector-button',
-  browsers: [
-    'chrome 89',
-    'edge 89',
-    'firefox 82',
-    'opera 75',
-    'safari 14.1',
-    'android 89',
-    'and_chr 89',
-    'op_mob 63',
-    'and_ff 82',
-    'ios_saf 14.5',
-    'samsung 15.0'
-  ]
-})
+let prefixFileSelectorButton = require('caniuse-lite/data/features/css-file-selector-button')
+
+f(prefixFileSelectorButton, browsers =>
+  prefix(['::file-selector-button'], {
+    selector: true,
+    feature: 'file-selector-button',
+    browsers
+  })
+)
 
 // :autofill
 let prefixAutofill = require('caniuse-lite/data/features/css-autofill')


### PR DESCRIPTION
This PR changes file-selector-button to pull data from caniuse-lite (which in turn generates it from MDN see https://github.com/browserslist/caniuse-lite/pull/90).

Previously this data was hardcoded but it seems I may have done this wrong originally, rather than trying to fix the hardcoded data it makes more sense to do what I did for the autofill data.