### PR TITLE
Fix CLI dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ module.exports = {
 You can use the [postcss-cli] to run Autoprefixer from CLI:
 
 ```sh
-npm install postcss-cli autoprefixer
+npm install postcss postcss-cli autoprefixer
 npx postcss *.css --use autoprefixer -d build/
 ```
 


### PR DESCRIPTION
Without `postcss` fails with error:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'postcss' `