### PR TITLE
Update `funding` key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,16 @@
   "main": "lib/autoprefixer.js",
   "bin": "bin/autoprefixer",
   "types": "lib/autoprefixer.d.ts",
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/postcss/"
-  },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/postcss/"
+    },
+    {
+      "type": "tidelift",
+      "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+    }
+  ],
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",
   "repository": "postcss/autoprefixer",


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. The `funding` key in package.json accepts an array for all the ways for funding a package, see [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!
