### PR TITLE
Improves startup time by requiring specific caniuse files (#1492)

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -1,4 +1,4 @@
-let unpack = require('caniuse-lite').feature
+let unpack = require('caniuse-lite/dist/unpacker/feature')
 
 function browsersSort(a, b) {
   a = a.split(' ')

--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -1,5 +1,5 @@
 let browserslist = require('browserslist')
-let { agents } = require('caniuse-lite')
+let { agents } = require('caniuse-lite/dist/unpacker/agents')
 let pico = require('picocolors')
 
 let Browsers = require('./browsers')

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -1,5 +1,5 @@
 let browserslist = require('browserslist')
-let agents = require('caniuse-lite/dist/unpacker/agents').agents
+let { agents } = require('caniuse-lite/dist/unpacker/agents')
 
 let utils = require('./utils')
 

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -1,5 +1,5 @@
 let browserslist = require('browserslist')
-let agents = require('caniuse-lite').agents
+let agents = require('caniuse-lite/dist/unpacker/agents').agents
 
 let utils = require('./utils')
 

--- a/lib/supports.js
+++ b/lib/supports.js
@@ -1,5 +1,5 @@
 let featureQueries = require('caniuse-lite/data/features/css-featurequeries.js')
-let { feature } = require('caniuse-lite')
+let feature = require('caniuse-lite/dist/unpacker/feature')
 let { parse } = require('postcss')
 
 let Browsers = require('./browsers')

--- a/test/browsers.test.js
+++ b/test/browsers.test.js
@@ -1,5 +1,5 @@
 let { equal, is } = require('uvu/assert')
-let { agents } = require('caniuse-lite')
+let { agents } = require('caniuse-lite/dist/unpacker/agents')
 let { join } = require('path')
 let { test } = require('uvu')
 

--- a/test/info.test.js
+++ b/test/info.test.js
@@ -1,6 +1,6 @@
 let { equal, match } = require('uvu/assert')
 let browserslist = require('browserslist')
-let { agents } = require('caniuse-lite')
+let { agents } = require('caniuse-lite/dist/unpacker/agents')
 let { test } = require('uvu')
 
 let Browsers = require('../lib/browsers')

--- a/test/prefixes.test.js
+++ b/test/prefixes.test.js
@@ -1,5 +1,5 @@
 let { equal, is } = require('uvu/assert')
-let { agents } = require('caniuse-lite')
+let { agents } = require('caniuse-lite/dist/unpacker/agents')
 let { parse } = require('postcss')
 let { test } = require('uvu')
 


### PR DESCRIPTION
In my case the time spent on require-ing `caniuse-lite` was reduced from ~300ms to ~100ms (tested on node 16.19.0).