### PR TITLE
feat: `::backdrop` using `@mdn/browser-compat-data`

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -256,9 +256,9 @@ f(prefixFilterFunction, browsers =>
 )
 
 // Backdrop-filter
-let prefixBackdrop = require('caniuse-lite/data/features/css-backdrop-filter')
+let prefixBackdropFilter = require('caniuse-lite/data/features/css-backdrop-filter')
 
-f(prefixBackdrop, { match: /y\sx|y\s#2/ }, browsers =>
+f(prefixBackdropFilter, { match: /y\sx|y\s#2/ }, browsers =>
   prefix(['backdrop-filter'], {
     browsers,
     feature: 'css-backdrop-filter'
@@ -513,10 +513,14 @@ f(prefixFullscreen, browsers =>
   })
 )
 
-f(prefixFullscreen, { match: /x(\s#2|$)/ }, browsers =>
+// ::backdrop pseudo-element
+// https://caniuse.com/mdn-css_selectors_backdrop
+let prefixBackdrop = require('caniuse-lite/data/features/mdn-css-backdrop-pseudo-element')
+
+f(prefixBackdrop, browsers =>
   prefix(['::backdrop'], {
     browsers,
-    feature: 'fullscreen',
+    feature: 'backdrop',
     selector: true
   })
 )

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -60,6 +60,9 @@ let selectorer = autoprefixer({
 let fileSelectorButtoner = autoprefixer({
   overrideBrowserslist: ['Chrome > 25', 'Firefox >= 82']
 })
+let backdroper = autoprefixer({
+  overrideBrowserslist: ['IE >= 11', 'Chrome < 32', 'Safari >= 15.4']
+})
 let placeholderShowner = autoprefixer({
   overrideBrowserslist: ['IE >= 10']
 })
@@ -146,6 +149,8 @@ function prefixer(name) {
     return selectorer
   } else if (name === 'selectors' || name === 'file-selector-button') {
     return fileSelectorButtoner
+  } else if (name === 'selectors' || name === 'backdrop') {
+    return backdroper
   } else if (
     name === 'selectors' ||
     name === 'autofill' ||
@@ -758,6 +763,10 @@ test('supports all fullscreens', () => {
 
 test('supports file-selector-button', () => {
   check('file-selector-button')
+})
+
+test('supports ::backdrop', () => {
+  check('backdrop')
 })
 
 test('supports custom prefixes', () => {

--- a/test/cases/backdrop.css
+++ b/test/cases/backdrop.css
@@ -1,0 +1,3 @@
+::backdrop {
+  color: green;
+}

--- a/test/cases/backdrop.out.css
+++ b/test/cases/backdrop.out.css
@@ -1,0 +1,6 @@
+::-ms-backdrop {
+  color: green;
+}
+::backdrop {
+  color: green;
+}


### PR DESCRIPTION
Before that, we added the `-wekbit-` prefix to Safari, which is not really needed.

Waiting for upstream PR: https://github.com/browserslist/caniuse-lite/pull/116