### PR TITLE
Remove deprecated browsers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,7 @@ and automation.
 If you can’t move to a build tool, you can use text editor plugins:
 
 * [Visual Studio Code](https://github.com/mrmlnc/vscode-autoprefixer)
-* [Atom Editor](https://github.com/sindresorhus/atom-autoprefixer)
 * [Sublime Text](https://github.com/sindresorhus/sublime-autoprefixer)
-* [Brackets](https://github.com/mikaeljorhult/brackets-autoprefixer)
 
 [Parcel]: https://parceljs.org/
 


### PR DESCRIPTION
Brackets and Atom code editors have long since been deprecated and neither plugin has been updated in even longer. I think it makes sense to remove links to these.

REF:
- https://github.com/sindresorhus/atom-autoprefixer
- https://github.com/mikaeljorhult/brackets-autoprefixer