### PR TITLE
improve performance

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -458,12 +458,12 @@ class Processor {
    * Check for grid/flexbox options.
    */
   disabledDecl(node, result) {
-    if (this.gridStatus(node, result) === false && node.type === 'decl') {
+    if (node.type === 'decl' && this.gridStatus(node, result) === false) {
       if (node.prop.includes('grid') || node.prop === 'justify-items') {
         return true
       }
     }
-    if (this.prefixes.options.flexbox === false && node.type === 'decl') {
+    if (node.type === 'decl' && this.prefixes.options.flexbox === false) {
       let other = ['order', 'justify-content', 'align-items', 'align-content']
       if (node.prop.includes('flex') || other.includes(node.prop)) {
         return true
@@ -641,15 +641,16 @@ class Processor {
     })
 
     // Selectors
-    for (let checker of this.prefixes.remove.selectors) {
-      css.walkRules((rule, i) => {
+    css.walkRules((rule, i) => {
+      if (this.disabled(rule, result)) return
+
+      for (let checker of this.prefixes.remove.selectors) {
         if (checker.check(rule)) {
-          if (!this.disabled(rule, result)) {
-            rule.parent.removeChild(i)
-          }
+          rule.parent.removeChild(i)
+          return
         }
-      })
-    }
+      }
+    })
 
     return css.walkDecls((decl, i) => {
       if (this.disabled(decl, result)) return


### PR DESCRIPTION
```
Lightning CSS:    5 ms   (7.5 times faster)
Stylis:           6 ms   (6.3 times faster)
Autoprefixer dev: 29 ms  (1.2 times faster)
Autoprefixer:     36 ms
Stylecow:         204 ms (5.7 times slower)
```

- do cheap checks before expensive checks
- loop inside walkers instead of the other way around