### PR TITLE
fix: add blocker `-moz` prefix for `:placeholder-shown`

### DIFF
--- a/lib/hacks/placeholder-shown.js
+++ b/lib/hacks/placeholder-shown.js
@@ -1,6 +1,15 @@
 let Selector = require('../selector')
+let utils = require('../utils')
 
 class PlaceholderShown extends Selector {
+  constructor(name, prefixes, all) {
+    super(name, prefixes, all)
+
+    if (this.prefixes) {
+      this.prefixes = utils.uniq(this.prefixes.map(() => '-ms-'))
+    }
+  }
+
   /**
    * Return different selectors depend on prefix
    */


### PR DESCRIPTION
## Description

When Autoprefixer parses the `:placeholder-shown`, the following results are obtained in [Autoprefixer CSS online](https://autoprefixer.github.io/).

![autoprefixer](https://github.com/user-attachments/assets/186d457e-9768-4e4d-aca1-26aaeee549f3)

However, `:-moz-placeholder-shown` doesn't exist at [Mozilla-only properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#mozilla-only_properties).

![mozilla](https://github.com/user-attachments/assets/75d7ca92-d9a0-45c9-9686-2d8105ee04a8)

That's why I removed the `-moz` prefix from [placeholder-shown.js](https://github.com/postcss/autoprefixer/blob/main/lib/hacks/placeholder-shown.js).