### PR TITLE
fix: remove `:-moz-placeholder` from `:placeholder-shown` property in Firefox > 50

### DIFF
--- a/lib/hacks/placeholder-shown.js
+++ b/lib/hacks/placeholder-shown.js
@@ -5,10 +5,11 @@ class PlaceholderShown extends Selector {
    * Return different selectors depend on prefix
    */
   prefixed(prefix) {
+    if (prefix === '-ms-') {
+      return ':-ms-input-placeholder'
+    }
     if (prefix === '-moz-') {
       return ':-moz-placeholder'
-    } else if (prefix === '-ms-') {
-      return ':-ms-input-placeholder'
     }
     return `:${prefix}placeholder-shown`
   }

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -64,7 +64,7 @@ let backdroper = autoprefixer({
   overrideBrowserslist: ['IE >= 11', 'Chrome < 32', 'Safari >= 15.4']
 })
 let placeholderShowner = autoprefixer({
-  overrideBrowserslist: ['IE >= 10']
+  overrideBrowserslist: ['IE >= 10', 'Firefox >= 4']
 })
 let transitionSpec = autoprefixer({
   overrideBrowserslist: ['Chrome > 19', 'Firefox 14', 'IE 10', 'Opera 12']

--- a/test/cases/placeholder-shown.out.css
+++ b/test/cases/placeholder-shown.out.css
@@ -1,3 +1,6 @@
+:-moz-placeholder {
+  background: #eee
+}
 :-ms-input-placeholder {
   background: #eee
 }


### PR DESCRIPTION
## Description

Fix #1533.

I have changed the behavior of `:placeholder-shown` at #1532.
However, this introduced the bug with `:not()` pseudo-class.

For example, see the [comment](https://github.com/postcss/autoprefixer/pull/1532#issuecomment-2718052371).

To solve this issue, `:-moz-placeholder` is given only for Firefox under 50 version.
Furthermore, I updated the [placeholder-shown.out.css](https://github.com/postcss/autoprefixer/blob/541295c0e6dd348db2d3f52772b59cd403c59d29/test/cases/placeholder-shown.out.css) test.