### PR TITLE
perf: reduce array allocations

### DIFF
--- a/lib/hacks/gradient.js
+++ b/lib/hacks/gradient.js
@@ -352,7 +352,7 @@ class Gradient extends Value {
 
     node.nodes = []
     for (let param of params) {
-      node.nodes = node.nodes.concat(param)
+      node.nodes.push(...param)
     }
 
     node.nodes.unshift(

--- a/lib/hacks/grid-utils.js
+++ b/lib/hacks/grid-utils.js
@@ -135,13 +135,14 @@ exports.prefixTrackValue = prefixTrackValue
 function prefixTrackValue({ gap, value }) {
   let result = parser(value).nodes.reduce((nodes, node) => {
     if (node.type === 'function' && node.value === 'repeat') {
-      return nodes.concat({
+      nodes.push({
         type: 'word',
         value: transformRepeat(node, { gap })
       })
+      return nodes
     }
     if (gap && node.type === 'space') {
-      return nodes.concat(
+      nodes.push(
         {
           type: 'space',
           value: ' '
@@ -152,8 +153,10 @@ function prefixTrackValue({ gap, value }) {
         },
         node
       )
+      return nodes
     }
-    return nodes.concat(node)
+    nodes.push(node)
+    return nodes
   }, [])
 
   return parser.stringify(result)
@@ -1046,7 +1049,8 @@ function normalizeRowColumn(str) {
     if (node.type === 'space') {
       return result
     }
-    return result.concat(parser.stringify(node))
+    result.push(parser.stringify(node))
+    return result
   }, [])
 
   return normalized

--- a/lib/transition.js
+++ b/lib/transition.js
@@ -314,7 +314,7 @@ class Transition {
       if (param[param.length - 1].type !== 'div') {
         param.push(this.div(params))
       }
-      nodes = nodes.concat(param)
+      nodes.push(...param)
     }
     if (nodes[0].type === 'div') {
       nodes = nodes.slice(1)


### PR DESCRIPTION
While benchmarking our build on a large project, I spotted a few places where `concat()` in loops could be replaced with `push()` to avoid repeated array allocations.

I imagine most projects won't notice this micro-optimisation, but on stylesheets with many transitions we did see ~15-20% faster processing.