### PR TITLE
Remove wrong placeholder-shown prefixing for Firefox

### DIFF
--- a/lib/hacks/placeholder-shown.js
+++ b/lib/hacks/placeholder-shown.js
@@ -5,9 +5,7 @@ class PlaceholderShown extends Selector {
    * Return different selectors depend on prefix
    */
   prefixed(prefix) {
-    if (prefix === '-moz-') {
-      return ':-moz-placeholder'
-    } else if (prefix === '-ms-') {
+    if (prefix === '-ms-') {
       return ':-ms-input-placeholder'
     }
     return `:${prefix}placeholder-shown`


### PR DESCRIPTION
Replacing `:placeholder-shown` with `:-moz-placeholder` breaks in Firefox. While placeholder-shown is working fine (supported since Jan. 2017), the `:-moz-placeholder` added by autoprefixer breaks selectors with `:not`:

Example:

```
input[placeholder]:not(:placeholder-shown) ~ label {
    top: 16px;
    font-size: 12px;
}
```
produces:
```
.form .field .input input[placeholder]:not(:-moz-placeholder)~label,
.form .field .input input[placeholder]:not(:placeholder-shown)~label{
    top: 16px;
    font-size: 12px;
}
```
This always applies, even if the placeholder is shown, because `:not(:-moz-placeholder)` evaluates to true.

I couldn't find any resources stating that `:-moz-placeholder` behaves like `:placeholder-shown`, so I wonder why it's in here?