### PR TITLE
Add prefixing support for mask-position-x and mask-position-y

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -750,6 +750,8 @@ f(prefixCssMasks, browsers => {
     [
       'mask',
       'mask-position',
+      'mask-position-x',
+      'mask-position-y',
       'mask-size',
       'mask-border',
       'mask-border-outset',

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -817,6 +817,10 @@ test('supports mask-composite', () => {
   check('mask-composite')
 })
 
+test('supports mask-position-x and mask-position-y', () => {
+  check('mask-position')
+})
+
 test('supports image-set()', () => {
   check('image-set')
 })

--- a/test/cases/mask-position.css
+++ b/test/cases/mask-position.css
@@ -1,0 +1,5 @@
+a {
+  mask-position: center;
+  mask-position-x: 10px;
+  mask-position-y: 20px;
+}

--- a/test/cases/mask-position.out.css
+++ b/test/cases/mask-position.out.css
@@ -1,0 +1,8 @@
+a {
+  -webkit-mask-position: center;
+          mask-position: center;
+  -webkit-mask-position-x: 10px;
+          mask-position-x: 10px;
+  -webkit-mask-position-y: 20px;
+          mask-position-y: 20px;
+}


### PR DESCRIPTION
Closes #1537

Adds `-webkit-mask-position-x` and `-webkit-mask-position-y` to the css-masks prefix list. Also adds `-x` support as requested in the issue.

These properties have [97%+ global browser support](https://caniuse.com/mdn-css_properties_-webkit-mask-position-y).