### PR TITLE
fix: don't duplicate prefixed rule when selector list was reformatted

### DIFF
--- a/lib/selector.js
+++ b/lib/selector.js
@@ -38,10 +38,12 @@ class Selector extends Prefixer {
         return false
       }
 
+      let beforeSelector = list.comma(before.selector).join(', ')
+
       let some = false
       for (let key in prefixeds[this.name]) {
         let prefixed = prefixeds[this.name][key]
-        if (before.selector === prefixed) {
+        if (beforeSelector === prefixed) {
           if (prefix === key) {
             return true
           } else {

--- a/test/selector.test.js
+++ b/test/selector.test.js
@@ -86,6 +86,15 @@ test('finds prefixed even if unknown prefix is between', () => {
   is(selector.already(css.nodes[2], prefixeds, '-moz-'), true)
 })
 
+test('finds prefixed even if selector list was reformatted', () => {
+  let css = parse(
+    '.a::-moz-selection,\n.b::-moz-selection {}\n' +
+      '.a::selection,\n.b::selection {}'
+  )
+  let prefixeds2 = selector.prefixeds(css.nodes[1])
+  is(selector.already(css.nodes[1], prefixeds2, '-moz-'), true)
+})
+
 test('adds prefix to selectors', () => {
   equal(
     selector.replace('body ::selection, input::selection, a', '-ms-'),


### PR DESCRIPTION
## Summary

Autoprefixer's output was not idempotent for prefixed rules whose selector list had been reformatted: running it again inserted a duplicate prefixed rule on every pass (#1497).

## Root cause

`Selector.already()` decides whether a prefixed rule already exists by comparing `before.selector` to the generated prefixed selector with strict equality:

```js
if (before.selector === prefixed) {
```

Generated prefixed selectors always join the comma list with `', '`. Once an existing prefixed rule had its selector list reformatted (for example, one selector per line by a code formatter), `before.selector` no longer matched the normalized generated string, the duplication check failed, and a duplicate prefixed rule was added.

## Fix

Normalize the compared selector with `list.comma(before.selector).join(', ')` before the comparison, so purely cosmetic whitespace differences in the selector list no longer defeat the duplication check.

## Tests

Added a test in `test/selector.test.js` covering `already()` when the existing prefixed rule's selector list was reformatted (one selector per line).

Fixes #1497
