### PR TITLE
Remove prefixed values overridden by a later declaration

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -682,7 +682,10 @@ class Processor {
         if (!checker.check(decl.value)) continue
 
         let notHack = this.prefixes.group(decl).down(other => {
-          return !Browsers.withPrefix(other.value)
+          if (this.prefixes.browsers.selected.length === 0) {
+            return !Browsers.withPrefix(other.value)
+          }
+          return other.value.includes(checker.unprefixed)
         })
 
         if (notHack) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,5 +1,6 @@
 let parser = require('postcss-value-parser')
 
+let Browsers = require('./browsers')
 let Value = require('./value')
 let insertAreas = require('./hacks/grid-utils').insertAreas
 
@@ -680,9 +681,8 @@ class Processor {
         if (!checker.check) continue
         if (!checker.check(decl.value)) continue
 
-        unprefixed = checker.unprefixed
         let notHack = this.prefixes.group(decl).down(other => {
-          return other.value.includes(unprefixed)
+          return !Browsers.withPrefix(other.value)
         })
 
         if (notHack) {

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -25,6 +25,9 @@ let filterer = autoprefixer({
 let borderer = autoprefixer({
   overrideBrowserslist: ['Safari 4', 'Firefox 3.6']
 })
+let fallbacker = autoprefixer({
+  overrideBrowserslist: ['Safari 12']
+})
 let cascader = autoprefixer({
   cascade: true,
   overrideBrowserslist: ['Chrome > 19', 'Firefox 21', 'IE 10']
@@ -169,6 +172,8 @@ function prefixer(name) {
     return keyframer
   } else if (name === 'border-radius') {
     return borderer
+  } else if (name === 'value-fallback') {
+    return fallbacker
   } else if (name === 'gradient') {
     return gradienter
   } else if (name === 'gradient-fix') {
@@ -370,6 +375,10 @@ test('keeps vendor-specific hacks', () => {
 
 test('keeps values with vendor hacks', () => {
   check('value-hack')
+})
+
+test('keeps prefixed value when the next value is not supported', () => {
+  check('value-fallback')
 })
 
 test('works with comments', () => {

--- a/test/cases/value-fallback.css
+++ b/test/cases/value-fallback.css
@@ -1,0 +1,9 @@
+.fallback {
+  width: -webkit-calc(100% - 20px);
+  width: clamp(10rem, 50%, 60rem);
+}
+
+.overridden {
+  display: -webkit-box;
+  display: flex;
+}

--- a/test/cases/value-fallback.out.css
+++ b/test/cases/value-fallback.out.css
@@ -1,0 +1,8 @@
+.fallback {
+  width: -webkit-calc(100% - 20px);
+  width: clamp(10rem, 50%, 60rem);
+}
+
+.overridden {
+  display: flex;
+}

--- a/test/cases/value-hack.css
+++ b/test/cases/value-hack.css
@@ -11,6 +11,12 @@
   transition: filter 1s;
 }
 
+.not-hack3 {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: none;
+}
+
 .hack {
   width: -webkit-calc(30% + 1px);
   display: -webkit-box;

--- a/test/cases/value-hack.out.css
+++ b/test/cases/value-hack.out.css
@@ -8,6 +8,10 @@
   transition: filter 1s;
 }
 
+.not-hack3 {
+  display: none;
+}
+
 .hack {
   width: -webkit-calc(30% + 1px);
   display: -webkit-box;


### PR DESCRIPTION
Fixes #1461

## Summary

With prefix removal active — an empty browserslist, `>100%`, or simply a prefix that has
become outdated for the configured browsers — `-ms-flexbox` was left behind whenever the
final `display` value was anything other than `flex`:

```css
.example {
  display: -webkit-box;
  display: -ms-flexbox;
  display: none;
}
```

```css
/* before */                /* after */
.example {                  .example {
  display: -ms-flexbox;       display: none;
  display: none;            }
}
```

Worth noting the asymmetry the issue only half-states: `-webkit-box` *was* removed while
`-ms-flexbox` survived, so the output was internally inconsistent rather than merely
incomplete. Changing that last line to `display: flex` made both disappear correctly,
which is what made the bug look value-dependent.

## Root cause

The Values branch of `Processor#remove` decides "is this prefixed declaration one
Autoprefixer generated, or a deliberate hand-written hack?". The repo answers that by
**ordering**: `prefixes.group(decl).down()` walks forward over siblings sharing an
unprefixed property and stops at the first whose value carries no vendor prefix, using
`!Browsers.withPrefix(other.value)` in `lib/prefixes.js`. A prefixed declaration with an
unprefixed sibling below it is a generated fallback and can go; one with nothing below it
is a hack and stays.

The Values callback implemented that question as a raw substring test on the value, and it
was wrong in both directions:

- `'none'.includes('flex')` is `false`, so `-ms-flexbox` was judged a hack even though
  `display: none` sits directly below it and overrides it in every browser. The reported
  symptom.
- `'-ms-flexbox'.includes('flex')` is `true`, so `-webkit-box` accepted the *prefixed*
  `-ms-flexbox` as its "unprefixed sibling" and was removed. That is the only reason the
  two prefixes behaved differently.

The Properties branch just above is unaffected — it tests the property
(`normalize(other.prop) === unprefixed`) rather than the value.

## Change

The callback now asks the question the sibling walker three lines away already asks:

```js
return !Browsers.withPrefix(other.value)
```

Ordering stays the only hack signal: `down()` is still the only direction consulted, so a
prefixed declaration placed *after* the unprefixed one (`test/cases/vendor-hack.css` `.c`)
and a lone prefixed declaration with no sibling below it (`value-hack.css` `.hack`) are
both still preserved. The `unprefixed = checker.unprefixed` assignment that the change
leaves unread is removed with it.

## Intentional behaviour change

Removal now applies whenever a later declaration overrides the prefixed one, even when it
does not name the same feature:

```css
a {
  background: -webkit-linear-gradient(top, white, black);
  background: red;
}
/* before: both kept.   after: `background: red` only. */
```

This is the same reasoning that makes `display: none` remove `-ms-flexbox` — a later
declaration the browser understands always overrides the earlier prefixed one, so the
prefixed declaration is dead code in every browser. It applies under real browserslist
configs, not only empty ones. No existing test covered it, so I would rather name it here
than leave it to be found in review.

Prefixes that are still needed are not affected, since the loop only runs on values
already in the `remove` set. I checked the cases that would matter: with `ie 10` an
`-ms-flexbox` / `flex` pair is left intact, and with `safari 6` a prefixed gradient above
its unprefixed twin is left intact.

## Tests

`test/cases/value-hack.css` gains a `.not-hack3` case covering the reported input. I
reused that fixture rather than adding one — it is already wired to `cleaner` and is
deliberately absent from `COMMONS`, so it is not round-tripped by
`removes unnecessary prefixes`. Reverting `lib/processor.js` while keeping the fixture
turns the case red, so it does pin the fix rather than passing either way.

```
pnpm run unit           246 / 246   (246 / 246 before the change)
pnpm run test:lint      clean
pnpm run test:coverage  100% lines
pnpm run test:size      69.87 kB / 70 kB limit
```
