### PR TITLE
Fix old WebKit gradients with color hints

### DIFF
--- a/lib/hacks/gradient.js
+++ b/lib/hacks/gradient.js
@@ -361,6 +361,17 @@ class Gradient extends Value {
     }
 
     this.oldDirection(params)
+    for (let param of params.slice(1)) {
+      let tokens = param.filter(i => i.type === 'word' || i.type === 'function')
+      if (
+        tokens.length === 1 &&
+        ((tokens[0].type === 'word' && parser.unit(tokens[0].value)) ||
+          (tokens[0].type === 'function' &&
+            /^(calc|min|max|clamp)$/i.test(tokens[0].value)))
+      ) {
+        return false
+      }
+    }
     this.colorStops(params)
 
     node.nodes = []

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -913,6 +913,56 @@ test('skips old webkit gradient for CSS variables', () => {
   equal(result.css.includes('-webkit-linear-gradient('), true)
 })
 
+test('skips old webkit gradients with color hints', () => {
+  let values = [
+    'linear-gradient(red 10%, 30%, blue 90%)',
+    'linear-gradient(to top, red 10%, 30%, blue 90%)',
+    'linear-gradient(red, 0, blue)',
+    'linear-gradient(red, 2em, blue)',
+    'linear-gradient(red, calc(20% + 10%), blue)',
+    'linear-gradient(red, min(20%, 30%), blue)',
+    'linear-gradient(red, max(20%, 30%), blue)',
+    'linear-gradient(red, clamp(20%, 30%, 40%), blue)',
+    'linear-gradient(red, /* hint */ 30% /* end */, blue)'
+  ]
+  for (let value of values) {
+    let input = `a { background: ${value}; }`
+    let result = postcss([gradienter]).process(input)
+
+    equal(result.css.includes('-webkit-gradient('), false)
+    equal(result.css.includes('-webkit-linear-gradient('), true)
+    equal(result.css.includes(value), true)
+  }
+})
+
+test('keeps old webkit gradients with ordinary color stops', () => {
+  let input = 'a { background: linear-gradient(to top, rgba(0,0,0,0.5) 10%, ' +
+    'hsl(0,50%,50%) 30%, blue 90%); }'
+  let result = postcss([gradienter]).process(input)
+
+  equal(
+    result.root.first.first.value,
+    '-webkit-gradient(linear, left bottom, left top, ' +
+      'color-stop(10%, rgba(0,0,0,0.5)), ' +
+      'color-stop(30%, hsl(0,50%,50%)), color-stop(90%, blue))'
+  )
+})
+
+test('skips old webkit gradients when a background layer has a color hint', () => {
+  let values = [
+    'linear-gradient(red, blue), linear-gradient(red, 30%, blue)',
+    'linear-gradient(red, 30%, blue), linear-gradient(red, blue)'
+  ]
+  for (let value of values) {
+    let input = `a { background: ${value}; }`
+    let result = postcss([gradienter]).process(input)
+
+    equal(result.css.includes('-webkit-gradient('), false)
+    equal(result.css.includes(value), true)
+    equal(result.css.includes('-webkit-linear-gradient('), true)
+  }
+})
+
 test('does not throw on empty or malformed gradient arguments', () => {
   let inputs = [
     'a { background-image: linear-gradient() }',


### PR DESCRIPTION
With Browserslist set to `Chrome 25, Opera 12, Android 2.3`, `linear-gradient(red 10%, 30%, blue 90%)` currently produces an old WebKit gradient containing `color-stop(30%)`. That syntax needs both a position and a color, so it cannot represent a color hint.

Skip the old `-webkit-gradient` conversion when a standalone hint is present. The standard gradient and the other prefixed forms are preserved. The regression tests cover numeric and calculated hints, comments, directions, ordinary color stops, and multiple background layers.

Related to #1505. This addresses the invalid old WebKit conversion; it does not change which other vendor forms are generated.

Validation: the new regression tests fail before the fix; `pnpm test` passes on macOS and Linux (250 tests, 100% line coverage, lint and size checks). Historical browser rendering was not tested.
