### PR TITLE
Add support for prefixing initial-letter

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -1139,3 +1139,13 @@ f(prefixPrintAdjust, browsers =>
     feature: 'css-print-color-adjust'
   })
 )
+
+// initial-letter
+let prefixInitialLetter = require('caniuse-lite/data/features/css-initial-letter')
+
+f(prefixInitialLetter, browsers =>
+  prefix(['initial-letter'], {
+    browsers,
+    feature: 'css-initial-letter'
+  })
+)

--- a/test/autoprefixer.test.js
+++ b/test/autoprefixer.test.js
@@ -81,6 +81,9 @@ let backgrounder = autoprefixer({
 let resolutioner = autoprefixer({
   overrideBrowserslist: ['Safari 7', 'Opera 12', 'Firefox 15']
 })
+let letterer = autoprefixer({
+  overrideBrowserslist: ['Safari 15']
+})
 let overscroller = autoprefixer({
   overrideBrowserslist: ['Edge 17']
 })
@@ -187,6 +190,8 @@ function prefixer(name) {
     return example
   } else if (name === 'resolution') {
     return resolutioner
+  } else if (name === 'initial-letter') {
+    return letterer
   } else if (name === 'supports') {
     return supporter
   } else if (name === 'transition-spec') {
@@ -257,7 +262,8 @@ const COMMONS = [
   'grid-template',
   'grid-template-areas',
   'grid-gap',
-  'print-color-adjust'
+  'print-color-adjust',
+  'initial-letter'
 ]
 
 test.after.each(() => {
@@ -867,6 +873,10 @@ test('supports print-color-adjust', () => {
 
 test('supports backdrop-filter', () => {
   check('backdrop-filter')
+})
+
+test('supports initial-letter', () => {
+  check('initial-letter')
 })
 
 test('supports user-select hack for IE', () => {

--- a/test/cases/initial-letter.css
+++ b/test/cases/initial-letter.css
@@ -1,0 +1,3 @@
+.dropcap::first-letter {
+  initial-letter: 2;
+}

--- a/test/cases/initial-letter.out.css
+++ b/test/cases/initial-letter.out.css
@@ -1,0 +1,4 @@
+.dropcap::first-letter {
+  -webkit-initial-letter: 2;
+          initial-letter: 2;
+}


### PR DESCRIPTION
Fixes #1555.

Safari has required the `-webkit-` prefix for `initial-letter` across every version that implements it (9 through current 26.x), but Autoprefixer never adds it. caniuse-lite already has the correct data (the `x` prefix-required flag has been set for Safari since v9), it just wasn't wired up in `data/prefixes.js`.

Wired it up the same way as `appearance`/`print-color-adjust`:

```js
// initial-letter
let prefixInitialLetter = require('caniuse-lite/data/features/css-initial-letter')

f(prefixInitialLetter, browsers =>
  prefix(['initial-letter'], {
    browsers,
    feature: 'css-initial-letter'
  })
)
```

Input:
```css
.dropcap::first-letter {
  initial-letter: 2;
}
```

Output (targeting Safari):
```css
.dropcap::first-letter {
  -webkit-initial-letter: 2;
          initial-letter: 2;
}
```

Added `test/cases/initial-letter.css` / `.out.css` fixtures and a dedicated test, plus wired the new case into the `COMMONS` list so it's covered by the existing suite-wide checks.